### PR TITLE
Add opt-in Codex agent workflow for Crossplane OKF

### DIFF
--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: okf
+description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, and examples. Never invoke implicitly; the user must mention `$okf`.
+metadata:
+  version: "1.0"
+  license: Apache-2.0
+---
+
+# Crossplane OKF workflow
+
+Run this workflow only after the user explicitly invokes `$okf`. The skill metadata also disables implicit invocation. Do not treat a request that merely mentions OKF, Crossplane, a provider, or a function as permission to start this workflow.
+
+The root agent owns all writes. Subagents are bounded, read-only researchers that return evidence packets.
+
+## Inputs
+
+Derive the requested scope from the text following `$okf`:
+
+- source repositories or source groups
+- concepts, APIs, commands, providers, functions, examples, or resource batches
+- create, update, validate, or review operation
+- output path, defaulting to `catalog/`
+
+Read:
+
+- `references/sources.yaml`
+- `references/evidence-contract.md`
+- `references/okf-profile.md`
+- the current OKF v0.1 specification at `https://okf.md/spec/`
+
+Use the external OKF skill at `https://github.com/fabricioctelles/skills/blob/main/skills/okf-open-knowledge-format/SKILL.md` as additional authoring guidance, but prefer the normative OKF specification when guidance differs.
+
+## Workflow
+
+### 1. Bound the work
+
+Create the smallest useful source and concept set. Do not process every repository or every managed resource unless the user explicitly requests full coverage.
+
+For incremental work, inspect existing catalog concepts and source locks first. Regenerate only concepts affected by changed source paths or dependencies.
+
+### 2. Pin sources
+
+Resolve every selected repository to a full commit SHA before extracting knowledge. Record the resolved commits in `.okf/sources.lock.yaml` or update the existing lock file.
+
+Never cite a moving branch in generated knowledge. A repository homepage may be used as the frontmatter `resource`, but evidence citations must be immutable.
+
+### 3. Scout cheaply
+
+Use `okf-source-scout` for repository classification and high-signal path discovery.
+
+Batch repositories by source kind. Do not spawn one agent per repository. Prefer one scout task for up to five related repositories or one changed-source batch.
+
+Skip scouting when existing locks and evidence already identify the relevant files and their source paths have not changed.
+
+### 4. Research only what needs semantics
+
+Use `okf-crossplane-researcher` for Crossplane core, CLI, runtime, tools, native providers, functions, SDKs, examples, and testing tools.
+
+Use `okf-upjet-researcher` only for Upjet provider concepts that require Terraform correlation. Give it an explicit provider service or managed-resource batch. Do not ask it to map an entire provider in one run.
+
+Run independent read-heavy research in parallel, with at most three direct agents. Wait for all required evidence packets before writing. Never allow subagents to spawn subagents.
+
+### 5. Build a claim ledger
+
+Before writing Markdown, reduce the evidence packets to a claim ledger:
+
+- concept identifier
+- exact claim
+- supporting immutable citation
+- confidence: direct, corroborated, or inferred
+- version boundary
+- unresolved conflict or limitation
+
+Drop claims that do not improve the concept. Keep inferred claims clearly labelled in the final document or omit them.
+
+### 6. Write as the root agent
+
+Create or update OKF documents under `catalog/` according to `references/okf-profile.md`.
+
+Rules:
+
+- one independently useful concept per file
+- structural Markdown over long prose
+- package, schema, behavior, and examples are separate concepts when each is useful alone
+- preserve existing unknown frontmatter fields
+- add natural-language cross-links, not a generic link dump
+- add a numbered `# Citations` section for externally sourced claims
+- update affected `index.md` files for progressive disclosure
+- update `log.md` only with high-level knowledge changes
+
+Do not copy large documentation passages. Summarize and cite.
+
+### 7. Apply the Upjet evidence gate
+
+For every Upjet managed-resource concept, require all of these before publishing a Terraform relationship:
+
+- Crossplane group, version, and kind
+- Upjet configuration or generated metadata naming the Terraform resource
+- matching Terraform provider source, schema, or official documentation
+- explicit notes for Upjet or Crossplane transformations and additions
+
+When any link is missing, record the mapping as unresolved. Do not infer it from names.
+
+### 8. Validate deterministically
+
+Validate the three OKF v0.1 conformance rules:
+
+1. Every non-reserved Markdown file has parseable YAML frontmatter.
+2. Every concept frontmatter has a non-empty `type`.
+3. Reserved `index.md` and `log.md` files follow their specified structures.
+
+Also check:
+
+- source lock entries exist for all generated concepts
+- evidence citations contain immutable commit SHAs
+- cited files and line anchors resolve when network access is available
+- internal Markdown links are valid; report broken links as warnings because OKF permits them
+- no concept contains unresolved placeholders presented as facts
+
+Use an installed OKF linter when available, but do not add or install dependencies without the user's approval. Always retain the three core checks as the minimum validation gate.
+
+### 9. Review once
+
+After deterministic validation passes, use `okf-reviewer` on the changed concepts and their claim ledger. Do not invoke the reviewer while blocking validation errors remain.
+
+Fix blocking findings as the root agent, rerun targeted validation, and report remaining warnings explicitly.
+
+## Token and model policy
+
+- Use `gpt-5.6-luna` with low reasoning for inventory and routing.
+- Use `gpt-5.6-terra` with medium reasoning for normal source interpretation.
+- Use flagship `gpt-5.6` with high reasoning only for ambiguous Upjet-to-Terraform mappings.
+- Use one final high-reasoning review over changed concepts, not over all source repositories.
+- Prefer targeted searches, schemas, tests, and examples over recursive repository reads.
+- Return summaries and evidence references, never raw exploration output.
+- Reuse source locks, evidence packets, and unchanged concepts across runs.
+
+## Completion report
+
+Report:
+
+- concepts created, updated, or removed
+- pinned source commits used
+- validation results
+- reviewer status
+- unresolved mappings, conflicts, and permitted broken links
+- the narrowest next source batch, when more coverage is requested

--- a/.agents/skills/okf/agents/openai.yaml
+++ b/.agents/skills/okf/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Crossplane OKF"
+  short_description: "Build source-backed OKF knowledge for Crossplane"
+  default_prompt: "Use $okf to build or update the Crossplane knowledge catalog from pinned source repositories."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/okf/references/evidence-contract.md
+++ b/.agents/skills/okf/references/evidence-contract.md
@@ -1,0 +1,44 @@
+# Evidence packet contract
+
+Subagents return evidence to the root agent. They do not write OKF documents.
+
+Use this compact Markdown structure:
+
+```markdown
+## Scope
+- Repository: owner/name
+- Commit: full SHA
+- Requested area: path, package, command, API, or resource batch
+
+## Concept candidates
+### Stable concept identifier
+- Type: proposed OKF type
+- Title: proposed title
+- Summary: one sentence, source-backed
+- Claims:
+  - Claim text
+    - Evidence: commit-pinned URL with line range
+    - Confidence: direct | corroborated | inferred
+- Schema sources:
+  - path and purpose
+- Examples:
+  - path and what it demonstrates
+- Relationships:
+  - target concept and prose relationship
+- Limitations or conflicts:
+  - unresolved issue, version boundary, or source disagreement
+
+## Source inventory
+- path — reason it is authoritative
+
+## Unresolved
+- exact question and the missing evidence
+```
+
+Rules:
+
+- Use `direct` only when one authoritative source states or implements the claim.
+- Use `corroborated` when independent code, tests, examples, or documentation agree.
+- Use `inferred` only for a clearly labelled conclusion that is useful but not explicitly stated.
+- Include no raw logs, full files, or broad repository summaries.
+- Keep each packet bounded to the assigned scope.

--- a/.agents/skills/okf/references/okf-profile.md
+++ b/.agents/skills/okf/references/okf-profile.md
@@ -1,0 +1,66 @@
+# Crossplane OKF profile
+
+This profile adds authoring guidance without narrowing OKF v0.1 conformance.
+
+## Required by OKF v0.1
+
+- Every non-reserved Markdown concept has parseable YAML frontmatter.
+- Every concept has a non-empty `type`.
+- `index.md` and `log.md` follow their reserved roles.
+
+## Recommended frontmatter
+
+```yaml
+---
+type: Crossplane Function
+title: function-go-templating
+description: One sentence supported by the cited sources.
+resource: https://github.com/crossplane-contrib/function-go-templating
+tags: [crossplane, function]
+timestamp: 2026-07-11T00:00:00Z
+source_repository: crossplane-contrib/function-go-templating
+source_commit: <full SHA>
+source_paths:
+  - package/crossplane.yaml
+---
+```
+
+Use extension fields only when populated by evidence. Preserve unknown fields.
+
+## Preferred concept types
+
+- `Crossplane Core Concept`
+- `Crossplane API`
+- `Crossplane CLI Command`
+- `Crossplane Provider`
+- `Crossplane Managed Resource`
+- `Crossplane Function`
+- `Crossplane Function Input`
+- `Crossplane Development Guide`
+- `Crossplane Test Tool`
+- `Crossplane Example`
+- `Terraform Resource Reference`
+- `Reference`
+
+These values are conventions, not a closed taxonomy.
+
+## Body structure
+
+Use only sections that add evidence-backed value:
+
+- `# Overview`
+- `# Schema`
+- `# Behavior`
+- `# Examples`
+- `# Relationships`
+- `# Limitations`
+- `# Citations`
+
+Keep citations at the end. Use numbered Markdown links. Prefer commit-pinned GitHub blob URLs with line anchors.
+
+## Granularity
+
+- One independently useful concept per file.
+- Keep package knowledge separate from API schema, runtime behavior, and examples.
+- Do not mirror every generated type by default. Generate at resource level only when requested or when the resource is needed by another concept.
+- Use `index.md` for progressive disclosure instead of large overview pages.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -1,0 +1,81 @@
+version: 1
+
+normative_sources:
+  - id: okf-spec
+    url: https://okf.md/spec/
+  - id: okf-reference-spec
+    repository: GoogleCloudPlatform/knowledge-catalog
+    paths:
+      - okf/SPEC.md
+      - toolbox/mdcode/demo/okf/catalog
+
+primary_sources:
+  - id: crossplane
+    repository: crossplane/crossplane
+    kind: crossplane-core
+  - id: crossplane-cli
+    repository: crossplane/cli
+    kind: cli
+  - id: crossplane-runtime
+    repository: crossplane/crossplane-runtime
+    kind: provider-sdk
+  - id: crossplane-tools
+    repository: crossplane/crossplane-tools
+    kind: development-tools
+  - id: function-sdk-go
+    repository: crossplane/function-sdk-go
+    kind: function-sdk
+  - id: function-kro
+    repository: crossplane-contrib/function-kro
+    kind: function
+  - id: function-go-templating
+    repository: crossplane-contrib/function-go-templating
+    kind: function
+  - id: xprin
+    repository: crossplane-contrib/xprin
+    kind: composition-test-tool
+  - id: function-sequencer
+    repository: crossplane-contrib/function-sequencer
+    kind: function
+  - id: function-auto-ready
+    repository: crossplane-contrib/function-auto-ready
+    kind: function
+  - id: provider-kubernetes
+    repository: crossplane-contrib/provider-kubernetes
+    kind: native-provider
+  - id: provider-helm
+    repository: crossplane-contrib/provider-helm
+    kind: native-provider
+  - id: function-patch-and-transform
+    repository: crossplane-contrib/function-patch-and-transform
+    kind: function
+  - id: provider-upjet-aws
+    repository: crossplane-contrib/provider-upjet-aws
+    kind: upjet-provider
+    terraform_source: terraform-provider-aws
+  - id: provider-upjet-azure
+    repository: crossplane-contrib/provider-upjet-azure
+    kind: upjet-provider
+    terraform_source: terraform-provider-azurerm
+  - id: function-tag-manager
+    repository: crossplane-contrib/function-tag-manager
+    kind: function
+
+supporting_sources:
+  - id: upjet
+    repository: crossplane/upjet
+    kind: upjet-framework
+  - id: terraform-provider-aws
+    repository: hashicorp/terraform-provider-aws
+    kind: terraform-provider
+    documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+  - id: terraform-provider-azurerm
+    repository: hashicorp/terraform-provider-azurerm
+    kind: terraform-provider
+    documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+
+source_policy:
+  pin_commits: true
+  prefer_primary_sources: true
+  allow_unpinned_citations: false
+  allow_name_only_upjet_mapping: false

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -3,10 +3,11 @@ version: 1
 normative_sources:
   - id: okf-spec
     url: https://okf.md/spec/
-  - id: okf-reference-spec
+
+reference_sources:
+  - id: okf-demo-catalog
     repository: GoogleCloudPlatform/knowledge-catalog
     paths:
-      - okf/SPEC.md
       - toolbox/mdcode/demo/okf/catalog
 
 primary_sources:

--- a/.codex/agents/okf-crossplane-researcher.toml
+++ b/.codex/agents/okf-crossplane-researcher.toml
@@ -1,0 +1,22 @@
+name = "okf-crossplane-researcher"
+description = "Read-only Crossplane domain researcher for an explicitly invoked $okf workflow. Use for core, CLI, runtime, tools, providers, functions, examples, and composition testing semantics."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Extract source-backed Crossplane knowledge without editing files.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+Research rules:
+- Start from the scoped repositories and paths supplied by the root agent. Do not rescan unrelated repositories.
+- Prefer Go types, CRDs/OpenAPI schemas, package metadata, tests, and executable examples over README summaries when describing behavior.
+- Separate API shape, runtime behavior, authoring guidance, and examples into distinct concept candidates.
+- Record version boundaries and feature gates when the source makes them explicit.
+- For functions, inspect package metadata, input API types, RunFunction implementation, tests, and examples.
+- For providers, inspect package metadata, ProviderConfig/authentication APIs, managed-resource schemas, controllers, tests, and examples.
+- For Crossplane CLI and testing tools, identify commands, accepted inputs, outputs, and validation behavior from implementation and tests.
+- Deduplicate repeated evidence and return only the minimum excerpts needed to support each claim.
+
+Never write catalog files. Mark unsupported or conflicting claims explicitly.
+"""

--- a/.codex/agents/okf-reviewer.toml
+++ b/.codex/agents/okf-reviewer.toml
@@ -1,0 +1,19 @@
+name = "okf-reviewer"
+description = "Read-only evidence and conformance reviewer for catalog changes produced by an explicitly invoked $okf workflow."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review only the changed OKF documents and their evidence packets. Do not edit files.
+
+Check:
+1. Every material claim is supported by a citation or is clearly marked as an inference, limitation, or unresolved question.
+2. Citations point to immutable commits and the cited source supports the exact claim.
+3. Upjet-to-Terraform mappings contain the complete evidence chain and are not based on naming similarity.
+4. Generated schemas are attributed to their generator or source-of-truth configuration where available.
+5. Concepts are small, non-duplicative, correctly linked, and placed at the right level of the catalog.
+6. OKF reserved files and frontmatter follow the profile in `.agents/skills/okf/references/okf-profile.md`.
+7. Examples are copied or minimally adapted from validated sources, and adaptations are disclosed.
+
+Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains.
+"""

--- a/.codex/agents/okf-source-scout.toml
+++ b/.codex/agents/okf-source-scout.toml
@@ -1,0 +1,20 @@
+name = "okf-source-scout"
+description = "Fast, read-only inventory agent for an explicitly invoked $okf workflow. Use to classify repositories, locate authoritative files, and identify changed source areas."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "low"
+sandbox_mode = "read-only"
+developer_instructions = """
+Inventory source repositories without writing files.
+
+Return only a compact evidence packet using the contract in `.agents/skills/okf/references/evidence-contract.md`.
+
+Priorities:
+1. Resolve repository kind: Crossplane core, CLI/tooling, SDK/runtime, native provider, Upjet provider, function, or testing tool.
+2. Locate high-signal files before recursive reading: package metadata, API types, CRDs/OpenAPI schemas, config generators, examples, tests, README files, and design documents.
+3. Report immutable commit SHA, relevant paths, and why each path matters.
+4. Prefer targeted search and file reads. Do not dump directory trees, generated code, or complete files.
+5. Flag generated directories and recommend their source-of-truth generator or schema input.
+6. Stop after enough evidence exists to route deeper research.
+
+Never generate OKF prose, never edit the repository, and never claim behavior that is not supported by cited evidence.
+"""

--- a/.codex/agents/okf-upjet-researcher.toml
+++ b/.codex/agents/okf-upjet-researcher.toml
@@ -1,0 +1,24 @@
+name = "okf-upjet-researcher"
+description = "Read-only specialist for mapping Upjet-generated Crossplane managed resources to Terraform provider resources during an explicitly invoked $okf workflow."
+model = "gpt-5.6"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Correlate Upjet, Crossplane provider, and Terraform provider evidence. Do not edit files.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+Required mapping chain:
+1. Identify the Crossplane managed resource group, version, and kind.
+2. Find the Upjet provider configuration or generated metadata that names the Terraform resource.
+3. Locate the corresponding Terraform provider schema, implementation, or official resource documentation.
+4. Distinguish fields inherited from Terraform from Crossplane or Upjet additions such as provider references, management policies, initProvider, late initialization, references, selectors, connection details, and observation state.
+5. Record transformations, external-name behavior, references, sensitive fields, and known divergences only when directly supported.
+6. Cite every mapping step with immutable repository URLs. A matching name is not evidence.
+
+Token discipline:
+- Work on an explicit service or resource batch, not an entire provider.
+- Read generator configuration before generated Go code.
+- Read Terraform documentation only after the exact Terraform resource name is proven.
+- Return unresolved mappings instead of exploring indefinitely.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[agents]
+max_threads = 3
+max_depth = 1
+interrupt_message = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository guidance
+
+This repository contains an Open Knowledge Format (OKF) knowledge bundle for the Crossplane v2 ecosystem.
+
+## Default behavior
+
+- Do not start the OKF generation or enrichment workflow automatically.
+- Run the workflow only when the user explicitly invokes `$okf`.
+- Keep this file limited to repository-wide rules. The workflow lives in `.agents/skills/okf/`, and specialist behavior lives in `.codex/agents/`.
+
+## Ownership
+
+- The root agent owns planning, source selection, file edits, validation, commits, and pull request updates.
+- Subagents are read-only researchers. They return compact evidence packets and never edit the catalog.
+- Use at most three direct subagents at once. Do not create nested subagent trees.
+
+## Evidence rules
+
+- Treat source code, generated schemas, tests, examples, package metadata, and official documentation as evidence in that order of relevance to the claim.
+- Pin every source repository to an immutable commit before generating knowledge.
+- Cite source files with commit-pinned GitHub URLs and line ranges whenever practical.
+- Do not convert assumptions, name similarity, or undocumented behavior into facts.
+- For Upjet resources, do not infer a Terraform mapping from names alone. Require Upjet configuration or generated metadata that identifies the Terraform resource.
+- Preserve disagreements between source code and documentation as explicit notes instead of silently choosing one.
+
+## Output rules
+
+- Generated knowledge belongs under `catalog/`.
+- Every non-reserved OKF Markdown document must contain parseable YAML frontmatter with a non-empty `type` field.
+- `index.md` and `log.md` follow the OKF reserved-file rules.
+- Prefer small concept documents, structural Markdown, progressive disclosure, and citations over broad narrative pages.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,57 @@
-# okf-crossplane-v2
+# Open Knowledge Format for Crossplane v2
 
-LLM-wiki in [Open Knowledge Format](https://okf.md/spec/) for the Crossplane v2 ecosystem.
+This repository provides a structured knowledge catalog for the Crossplane v2 ecosystem using the [Open Knowledge Format](https://okf.md/spec/).
 
-## Codex workflow
+The goal is to make Crossplane concepts, APIs, providers, composition functions, development tools, and practical examples easier to discover and understand. The catalog is designed for both humans and knowledge-aware tools.
 
-The repository contains an opt-in Codex workflow for creating and maintaining the catalog from Crossplane source code, schemas, tests, examples, package metadata, and documentation.
+## Why this repository exists
 
-Invoke it explicitly:
+Crossplane knowledge is distributed across many repositories and different kinds of sources:
 
-```text
-$okf build knowledge for function-go-templating and function-kro
-```
+- Go API types and runtime implementations
+- CustomResourceDefinitions and OpenAPI schemas
+- package metadata
+- examples and tests
+- design documents and user documentation
 
-The `$okf` skill never activates implicitly. Its root agent is the only writer; token-efficient read-only subagents collect evidence for Crossplane and Upjet sources before the catalog is changed.
+Upjet-based providers add another layer. Their Crossplane managed resources are generated from Terraform provider resources, while the Terraform documentation often contains more details about the underlying cloud APIs and configuration fields.
 
-See:
+This repository connects these sources in one versioned catalog without replacing the original documentation.
 
-- [`AGENTS.md`](AGENTS.md) for repository-wide rules
-- [`.agents/skills/okf/SKILL.md`](.agents/skills/okf/SKILL.md) for the workflow
-- [`.agents/skills/okf/references/sources.yaml`](.agents/skills/okf/references/sources.yaml) for the source inventory
-- [`.codex/agents/`](.codex/agents/) for specialist agents
+## Scope
+
+The catalog covers:
+
+- Crossplane core concepts and APIs
+- the Crossplane CLI and development tools
+- provider development with `crossplane-runtime`
+- composition function development with `function-sdk-go`
+- common composition functions and testing tools
+- native providers such as `provider-kubernetes` and `provider-helm`
+- Upjet-based AWS and Azure providers
+- relationships between Upjet managed resources and their Terraform provider resources
+
+## Knowledge structure
+
+Knowledge is stored as small Markdown documents under `catalog/`. Each document represents an independently useful concept and includes OKF metadata, relationships to related concepts, and citations to the original sources.
+
+The catalog is intended to be:
+
+- **Source-backed:** important statements link to source code, schemas, tests, examples, or official documentation.
+- **Version-aware:** sources are tied to specific repository revisions.
+- **Navigable:** overview documents connect related concepts without requiring readers to know the source repository layout.
+- **Incremental:** providers, functions, services, and managed resources can be added in focused batches.
+
+## Upjet and Terraform resources
+
+For Upjet providers, a relationship between a Crossplane managed resource and a Terraform resource is documented only when it can be traced through the provider configuration or generated metadata.
+
+The catalog also describes Crossplane-specific behavior that is not part of the Terraform resource, such as references, selectors, provider configuration, management policies, late initialization, external names, and connection details.
+
+## Project status
+
+The catalog is built incrementally. Initial work focuses on the common Crossplane concepts, development libraries, composition functions, and representative providers before expanding into individual cloud services and managed resources.
+
+## Disclaimer
+
+This is an independent community project. It is not official Crossplane documentation and does not replace the documentation of Crossplane, its providers, or the underlying Terraform providers.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # okf-crossplane-v2
-LLM-wiki in OKF ([Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing?hl=en)) for Crossplane v2
+
+LLM-wiki in [Open Knowledge Format](https://okf.md/spec/) for the Crossplane v2 ecosystem.
+
+## Codex workflow
+
+The repository contains an opt-in Codex workflow for creating and maintaining the catalog from Crossplane source code, schemas, tests, examples, package metadata, and documentation.
+
+Invoke it explicitly:
+
+```text
+$okf build knowledge for function-go-templating and function-kro
+```
+
+The `$okf` skill never activates implicitly. Its root agent is the only writer; token-efficient read-only subagents collect evidence for Crossplane and Upjet sources before the catalog is changed.
+
+See:
+
+- [`AGENTS.md`](AGENTS.md) for repository-wide rules
+- [`.agents/skills/okf/SKILL.md`](.agents/skills/okf/SKILL.md) for the workflow
+- [`.agents/skills/okf/references/sources.yaml`](.agents/skills/okf/references/sources.yaml) for the source inventory
+- [`.codex/agents/`](.codex/agents/) for specialist agents


### PR DESCRIPTION
## Summary

- add a small repository-level `AGENTS.md`
- add an explicit-only `$okf` skill with implicit invocation disabled
- add read-only specialist agents for source scouting, Crossplane semantics, Upjet/Terraform correlation, and evidence review
- add a pinned-source and evidence contract for reproducible OKF generation
- add the requested Crossplane source inventory plus Upjet and Terraform supporting sources

## Workflow design

The root agent is the only writer and owns planning, catalog changes, validation, commits, and pull request updates. Subagents are bounded read-only researchers that return compact evidence packets.

The workflow uses at most three direct subagents with a maximum depth of one. It builds a claim ledger before writing, requires immutable source citations, validates OKF conformance deterministically, and runs one final evidence review.

The `$okf` workflow is opt-in only. `.agents/skills/okf/agents/openai.yaml` sets `allow_implicit_invocation: false`, and `AGENTS.md` explicitly prohibits automatic activation.

## Model and token efficiency

- `gpt-5.6-luna` with low reasoning for repository inventory and routing
- `gpt-5.6-terra` with medium reasoning for normal Crossplane source interpretation
- flagship `gpt-5.6` with high reasoning only for ambiguous Upjet-to-Terraform mappings
- `gpt-5.6-terra` with high reasoning for one final review over changed concepts
- targeted source batches, root-only writes, no nested subagents, and reuse of source locks and evidence packets

## Upjet evidence gate

An Upjet managed-resource relationship is published only when the workflow can prove the complete chain:

1. Crossplane group, version, and kind
2. Upjet configuration or generated metadata naming the Terraform resource
3. corresponding Terraform provider source, schema, or official documentation
4. explicit Crossplane and Upjet transformations or additions

Resource names alone are not accepted as evidence.

## Validation

- TOML files parsed successfully
- YAML files and skill frontmatter parsed successfully
- all repository content is written in English
- the feature branch is one commit ahead of `main`

`AGENTS.md` uses the official Codex repository-instructions filename; role-specific instructions remain in `.codex/agents/*.toml`.