### PR TITLE
Add Pi agent workflow for Crossplane OKF

### DIFF
--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: okf
-description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, and examples. Never invoke implicitly; the user must mention `$okf`.
+description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, and examples. Never invoke implicitly; the user must invoke `$okf`, `/skill:okf`, or `/okf`.
+disable-model-invocation: true
 metadata:
-  version: "1.1"
+  version: "1.2"
   license: Apache-2.0
 ---
 
 # Crossplane OKF workflow
 
-Run this workflow only after the user explicitly invokes `$okf`. The skill metadata also disables implicit invocation. Do not treat a request that merely mentions OKF, Crossplane, a provider, or a function as permission to start this workflow.
+Run this workflow only after the user explicitly invokes `$okf`, `/skill:okf`, or `/okf`. Do not treat a request that merely mentions OKF, Crossplane, a provider, or a function as permission to start this workflow.
 
-The root agent owns all writes. Subagents are bounded, read-only researchers that return evidence packets.
+The root or parent agent owns all writes. Subagents are bounded, read-only researchers that return evidence packets.
 
 ## Inputs
 
-Derive the requested scope from the text following `$okf`:
+Derive the requested scope from the explicit invocation:
 
 - source repositories or source groups
 - concepts, APIs, commands, providers, functions, documentation, examples, or resource batches
@@ -29,6 +30,16 @@ Read:
 - `references/okf-spec.md`
 
 Treat the source categories in `references/sources.yaml` as separate authority roles. Do not flatten primary source, official documentation, supporting source, and third-party example evidence into one undifferentiated source list.
+
+## Runtime adapters
+
+The workflow and evidence contracts are shared across agent runtimes:
+
+- Codex specialist definitions live in `.codex/agents/`.
+- Pi specialist definitions live in `.pi/agents/` and are loaded through `pi-subagents`.
+- Pi users may invoke the shared skill with `/skill:okf` or use the project prompt `/okf`.
+- Runtime-specific agents use the same `okf-*` role names and must preserve the same read-only evidence contract.
+- The root or parent agent remains the only writer regardless of runtime.
 
 ## Workflow
 
@@ -147,18 +158,32 @@ Use an installed OKF linter when available, but do not add or install dependenci
 
 After deterministic validation passes, use `okf-reviewer` on the changed concepts and their claim ledger. Do not invoke the reviewer while blocking validation errors remain.
 
-Fix blocking findings as the root agent, rerun targeted validation, and report remaining warnings explicitly.
+Fix blocking findings as the root or parent agent, rerun targeted validation, and report remaining warnings explicitly.
 
 ## Token and model policy
 
-- Use `gpt-5.6-luna` with low reasoning for inventory and routing.
-- Use `gpt-5.6-terra` with medium reasoning for normal source interpretation.
-- Use flagship `gpt-5.6` with high reasoning only for ambiguous Upjet-to-Terraform mappings.
+Shared rules:
+
+- Keep at most three direct research agents active at once.
 - Use one final high-reasoning review over changed concepts, not over all source repositories.
 - Prefer targeted searches, schemas, tests, documentation sections, and configured example paths over recursive repository reads.
 - Batch related third-party example repositories instead of assigning one agent per repository.
 - Return summaries and evidence references, never raw exploration output.
 - Reuse source locks, evidence packets, and unchanged concepts across runs.
+
+Codex model selection:
+
+- Use `gpt-5.6-luna` with low reasoning for inventory and routing.
+- Use `gpt-5.6-terra` with medium reasoning for normal source interpretation.
+- Use flagship `gpt-5.6` with high reasoning only for ambiguous Upjet-to-Terraform mappings.
+- Use `gpt-5.6-terra` with high reasoning for the final review.
+
+Pi model selection:
+
+- Project agents intentionally do not pin a provider-specific model identifier. They inherit the model selected for the Pi session.
+- Use the role-specific `thinking` levels declared in `.pi/agents/`.
+- Configure local or hosted models outside this repository so the workflow remains portable across Pi providers.
+- Use a stronger model or higher reasoning only for ambiguous Upjet mappings and the final evidence review.
 
 ## Completion report
 

--- a/.pi/agents/okf-crossplane-researcher.md
+++ b/.pi/agents/okf-crossplane-researcher.md
@@ -1,20 +1,15 @@
 ---
 name: okf-crossplane-researcher
 description: Read-only Crossplane researcher for source-backed OKF concepts, APIs, documentation, and examples.
-tools:
-  - read
-  - grep
-  - find
-  - ls
-  - bash
+tools: read, grep, find, ls, bash
 thinking: medium
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 defaultContext: fresh
 async: false
-turnBudget: 12
-maxSubagentDepth: 1
+turnBudget: {"maxTurns":12,"graceTurns":1}
+maxSubagentDepth: 0
 ---
 
 Extract source-backed Crossplane knowledge without editing the project.

--- a/.pi/agents/okf-crossplane-researcher.md
+++ b/.pi/agents/okf-crossplane-researcher.md
@@ -1,0 +1,42 @@
+---
+name: okf-crossplane-researcher
+description: Read-only Crossplane researcher for source-backed OKF concepts, APIs, documentation, and examples.
+tools:
+  - read
+  - grep
+  - find
+  - ls
+  - bash
+thinking: medium
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: 12
+maxSubagentDepth: 1
+---
+
+Extract source-backed Crossplane knowledge without editing the project.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+Research rules:
+
+- Start from the scoped repositories and paths supplied by the parent agent. Do not rescan unrelated repositories.
+- Preserve the assigned source role in every claim. Do not merge implementation, official documentation, and third-party examples into one authority class.
+- Prefer Go types, CRDs or OpenAPI schemas, package metadata, tests, and executable examples over README summaries when describing behavior.
+- Use official Crossplane documentation for documented terminology, guidance, workflows, and versioned user-facing examples.
+- Treat third-party repositories as illustrative. They may establish what that repository implements, but not general Crossplane behavior or recommended practice.
+- Restrict third-party research to configured paths and corroborate reusable patterns with primary sources or official documentation.
+- Separate API shape, runtime behavior, documented guidance, and illustrative examples into distinct concept candidates.
+- Record version boundaries and feature gates when the source makes them explicit.
+- For functions, inspect package metadata, input API types, the `RunFunction` implementation, tests, and examples.
+- For providers, inspect package metadata, ProviderConfig or authentication APIs, managed-resource schemas, controllers, tests, and examples.
+- For Crossplane CLI and testing tools, identify commands, accepted inputs, outputs, and validation behavior from implementation and tests.
+- Report licensing information before proposing copied or adapted third-party material. Otherwise summarize and cite.
+- Deduplicate repeated evidence and return only the minimum excerpts needed to support each claim.
+
+Use `bash` only for read-only inspection commands. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
+
+Never write catalog files. Mark unsupported, conflicting, version-specific, and repository-specific claims explicitly.

--- a/.pi/agents/okf-reviewer.md
+++ b/.pi/agents/okf-reviewer.md
@@ -1,0 +1,38 @@
+---
+name: okf-reviewer
+description: Read-only evidence and conformance reviewer for changed OKF documents and their claim ledgers.
+tools:
+  - read
+  - grep
+  - find
+  - ls
+  - bash
+thinking: high
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: 10
+maxSubagentDepth: 1
+---
+
+Review only the changed OKF documents and their evidence packets. Do not edit the project.
+
+Check:
+
+1. Every material claim is supported by a citation or is clearly marked as an inference, limitation, or unresolved question.
+2. Citations point to immutable commits and the cited source supports the exact claim.
+3. Source roles remain explicit: implementation, official documentation, supporting source, and third-party example evidence are not treated as interchangeable.
+4. Official documentation claims include the applicable Crossplane version scope and conflicts with implementation are disclosed.
+5. Third-party examples are labelled as community examples and are not the sole evidence for general Crossplane behavior, API semantics, compatibility, security properties, or recommended practice.
+6. Copied or adapted third-party material has verified license information and attribution; otherwise the concept only summarizes and cites the source.
+7. Upjet-to-Terraform mappings contain the complete evidence chain and are not based on naming similarity.
+8. Generated schemas are attributed to their generator or source-of-truth configuration where available.
+9. Concepts are small, non-duplicative, correctly linked, and placed at the right level of the catalog.
+10. OKF reserved files and frontmatter follow `.agents/skills/okf/references/okf-profile.md`.
+11. Examples are copied, adapted, or summarized accurately, and that distinction is disclosed.
+
+Use `bash` only for read-only validation and inspection commands. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
+
+Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains.

--- a/.pi/agents/okf-reviewer.md
+++ b/.pi/agents/okf-reviewer.md
@@ -1,20 +1,15 @@
 ---
 name: okf-reviewer
 description: Read-only evidence and conformance reviewer for changed OKF documents and their claim ledgers.
-tools:
-  - read
-  - grep
-  - find
-  - ls
-  - bash
+tools: read, grep, find, ls, bash
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 defaultContext: fresh
 async: false
-turnBudget: 10
-maxSubagentDepth: 1
+turnBudget: {"maxTurns":10,"graceTurns":1}
+maxSubagentDepth: 0
 ---
 
 Review only the changed OKF documents and their evidence packets. Do not edit the project.

--- a/.pi/agents/okf-source-scout.md
+++ b/.pi/agents/okf-source-scout.md
@@ -1,0 +1,37 @@
+---
+name: okf-source-scout
+description: Fast, read-only inventory agent for classifying OKF sources and locating high-signal files.
+tools:
+  - read
+  - grep
+  - find
+  - ls
+  - bash
+thinking: low
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: 8
+maxSubagentDepth: 1
+---
+
+Inventory source repositories without editing the project.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+Priorities:
+
+1. Resolve the source role: primary, official-documentation, supporting, or third-party-example.
+2. Resolve the repository kind: Crossplane core, CLI or tooling, SDK or runtime, native provider, Upjet provider, function, testing tool, documentation, or example implementation.
+3. Respect configured path restrictions, especially for documentation and third-party example repositories.
+4. Locate high-signal files before recursive reading: package metadata, API types, CRDs or OpenAPI schemas, generator configuration, examples, tests, README files, and design documents.
+5. Report the immutable commit SHA, relevant paths, source role, and why each path matters.
+6. Prefer targeted search and file reads. Do not dump directory trees, generated code, or complete files.
+7. Flag generated directories and identify their source-of-truth generator or schema input when available.
+8. Stop after enough evidence exists to route deeper research.
+
+Use `bash` only for read-only inspection commands. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
+
+Never generate OKF prose. Never claim behavior that is not supported by cited evidence. Do not promote a third-party example to an authoritative source.

--- a/.pi/agents/okf-source-scout.md
+++ b/.pi/agents/okf-source-scout.md
@@ -1,20 +1,15 @@
 ---
 name: okf-source-scout
 description: Fast, read-only inventory agent for classifying OKF sources and locating high-signal files.
-tools:
-  - read
-  - grep
-  - find
-  - ls
-  - bash
+tools: read, grep, find, ls, bash
 thinking: low
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 defaultContext: fresh
 async: false
-turnBudget: 8
-maxSubagentDepth: 1
+turnBudget: {"maxTurns":8,"graceTurns":1}
+maxSubagentDepth: 0
 ---
 
 Inventory source repositories without editing the project.

--- a/.pi/agents/okf-upjet-researcher.md
+++ b/.pi/agents/okf-upjet-researcher.md
@@ -1,0 +1,42 @@
+---
+name: okf-upjet-researcher
+description: Read-only specialist for evidence-backed Upjet, Crossplane, and Terraform resource mappings.
+tools:
+  - read
+  - grep
+  - find
+  - ls
+  - bash
+thinking: high
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: 16
+maxSubagentDepth: 1
+---
+
+Correlate Upjet, Crossplane provider, and Terraform provider evidence without editing the project.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+Required mapping chain:
+
+1. Identify the Crossplane managed-resource group, version, and kind.
+2. Find the Upjet provider configuration or generated metadata that names the Terraform resource.
+3. Locate the corresponding Terraform provider schema, implementation, or official resource documentation.
+4. Distinguish fields inherited from Terraform from Crossplane or Upjet additions such as provider references, management policies, `initProvider`, late initialization, references, selectors, connection details, and observation state.
+5. Record transformations, external-name behavior, references, sensitive fields, and known divergences only when directly supported.
+6. Cite every mapping step with immutable repository URLs. A matching name is not evidence.
+
+Token discipline:
+
+- Work on an explicit service or resource batch, not an entire provider.
+- Read generator configuration before generated Go code.
+- Read Terraform documentation only after the exact Terraform resource name is proven.
+- Return unresolved mappings instead of exploring indefinitely.
+
+Use `bash` only for read-only inspection commands. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
+
+Never write catalog files.

--- a/.pi/agents/okf-upjet-researcher.md
+++ b/.pi/agents/okf-upjet-researcher.md
@@ -1,20 +1,15 @@
 ---
 name: okf-upjet-researcher
 description: Read-only specialist for evidence-backed Upjet, Crossplane, and Terraform resource mappings.
-tools:
-  - read
-  - grep
-  - find
-  - ls
-  - bash
+tools: read, grep, find, ls, bash
 thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
 defaultContext: fresh
 async: false
-turnBudget: 16
-maxSubagentDepth: 1
+turnBudget: {"maxTurns":16,"graceTurns":2}
+maxSubagentDepth: 0
 ---
 
 Correlate Upjet, Crossplane provider, and Terraform provider evidence without editing the project.

--- a/.pi/prompts/okf.md
+++ b/.pi/prompts/okf.md
@@ -1,0 +1,12 @@
+---
+description: Build or update the Crossplane OKF catalog from source-backed evidence
+argument-hint: <scope>
+---
+
+Load and follow `.agents/skills/okf/SKILL.md` for this request.
+
+This command is explicit permission to run the OKF workflow for the scope below:
+
+$ARGUMENTS
+
+Follow `AGENTS.md`. Use only the project agents whose names start with `okf-` for delegated research. Subagents are read-only and must return compact evidence packets. The parent agent owns planning, source selection, catalog writes, deterministic validation, review coordination, and the completion report.

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,9 @@
+{
+  "packages": [
+    "pi-subagents"
+  ],
+  "enableSkillCommands": true,
+  "subagents": {
+    "disableBuiltins": true
+  }
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,6 +1,6 @@
 {
   "packages": [
-    "pi-subagents"
+    "npm:pi-subagents"
   ],
   "enableSkillCommands": true,
   "subagents": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,15 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 ## Default behavior
 
 - Do not start the OKF generation or enrichment workflow automatically.
-- Run the workflow only when the user explicitly invokes `$okf`.
-- Keep this file limited to repository-wide rules. The workflow lives in `.agents/skills/okf/`, and specialist behavior lives in `.codex/agents/`.
+- Run the workflow only when the user explicitly invokes `$okf`, `/skill:okf`, or `/okf`.
+- Keep this file limited to repository-wide rules. The shared workflow lives in `.agents/skills/okf/`; runtime-specific specialist definitions live in `.codex/agents/` and `.pi/agents/`.
 
 ## Ownership
 
-- The root agent owns planning, source selection, file edits, validation, commits, and pull request updates.
+- The root or parent agent owns planning, source selection, file edits, validation, commits, and pull request updates.
 - Subagents are read-only researchers. They return compact evidence packets and never edit the catalog.
 - Use at most three direct subagents at once. Do not create nested subagent trees.
+- When running in Pi, use only the project agents whose names start with `okf-`. Their tool allowlists intentionally omit editing tools and nested delegation.
 
 ## Evidence rules
 


### PR DESCRIPTION
## Summary

- add project-local Pi configuration with `pi-subagents`
- add an explicit `/okf <scope>` prompt that reuses the shared OKF skill
- add read-only Pi agents for source scouting, Crossplane research, Upjet mapping, and evidence review
- keep the root or parent agent as the only writer
- disable generic built-in subagents for this project
- document Pi-specific invocation and runtime behavior in the shared skill and repository guidance

## Pi integration

The project installs `npm:pi-subagents` through `.pi/settings.json` and exposes four project agents:

- `okf-source-scout`
- `okf-crossplane-researcher`
- `okf-upjet-researcher`
- `okf-reviewer`

Each agent has a restricted tool allowlist, a role-specific thinking level, a bounded turn budget, fresh context, and `maxSubagentDepth: 0` to prevent nested delegation.

The Pi agents intentionally do not pin provider-specific model identifiers. They inherit the model configured for the Pi session, which keeps the repository portable across local and hosted Pi providers.

## Shared workflow

The existing `.agents/skills/okf/SKILL.md` remains the single workflow definition. It now documents both runtime adapters:

- Codex agents in `.codex/agents/`
- Pi agents in `.pi/agents/`

Pi users can start the workflow explicitly with either `/skill:okf` or the project prompt `/okf`.

## Safety and token efficiency

- only the parent agent may write catalog files
- subagents perform read-only inspection and return compact evidence packets
- built-in generic subagents are disabled for the project
- nested subagent execution is disabled
- source scouting and normal research use lower reasoning than ambiguous Upjet mappings and final review
- turn budgets bound exploratory work

## Validation

- branch is based on the current `main`
- `.pi/settings.json` uses the documented `npm:pi-subagents` package source
- agent frontmatter was checked against the current `pi-subagents` parser and schema
- tool lists use the required comma-separated format
- turn budgets use the required JSON object format
- all four agents disable nested delegation with `maxSubagentDepth: 0`
- eight files are changed

A full runtime execution was not performed because Pi is not installed in the available execution environment.
