### PR TITLE
Support Qwen3-Coder-Next in Pi agents

### DIFF
--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -3,7 +3,7 @@ name: okf
 description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, and examples. Never invoke implicitly; the user must invoke `$okf`, `/skill:okf`, or `/okf`.
 disable-model-invocation: true
 metadata:
-  version: "1.2"
+  version: "1.3"
   license: Apache-2.0
 ---
 
@@ -37,6 +37,7 @@ The workflow and evidence contracts are shared across agent runtimes:
 
 - Codex specialist definitions live in `.codex/agents/`.
 - Pi specialist definitions live in `.pi/agents/` and are loaded through `pi-subagents`.
+- Pi model configuration guidance lives in `.pi/README.md`.
 - Pi users may invoke the shared skill with `/skill:okf` or use the project prompt `/okf`.
 - Runtime-specific agents use the same `okf-*` role names and must preserve the same read-only evidence contract.
 - The root or parent agent remains the only writer regardless of runtime.
@@ -165,7 +166,7 @@ Fix blocking findings as the root or parent agent, rerun targeted validation, an
 Shared rules:
 
 - Keep at most three direct research agents active at once.
-- Use one final high-reasoning review over changed concepts, not over all source repositories.
+- Use one final evidence review over changed concepts, not over all source repositories.
 - Prefer targeted searches, schemas, tests, documentation sections, and configured example paths over recursive repository reads.
 - Batch related third-party example repositories instead of assigning one agent per repository.
 - Return summaries and evidence references, never raw exploration output.
@@ -180,10 +181,11 @@ Codex model selection:
 
 Pi model selection:
 
-- Project agents intentionally do not pin a provider-specific model identifier. They inherit the model selected for the Pi session.
-- Use the role-specific `thinking` levels declared in `.pi/agents/`.
+- Project agents intentionally do not pin a provider-specific model identifier or thinking level. They inherit the model and supported capabilities selected for the Pi session.
 - Configure local or hosted models outside this repository so the workflow remains portable across Pi providers.
-- Use a stronger model or higher reasoning only for ambiguous Upjet mappings and the final evidence review.
+- Non-thinking coding models such as Qwen3-Coder-Next can run every project agent without incompatible reasoning controls.
+- Use a stronger or different model for ambiguous Upjet mappings and the final evidence review when one is available.
+- Follow `.pi/README.md` for local Qwen3-Coder-Next configuration guidance.
 
 ## Completion report
 

--- a/.pi/README.md
+++ b/.pi/README.md
@@ -1,0 +1,80 @@
+# Pi model configuration
+
+The project agents in `.pi/agents/` do not pin a provider, model, or thinking level. They inherit the model selected for the Pi session or the model configured through `pi-subagents`.
+
+Keeping model selection outside the repository allows the same OKF workflow to run with hosted reasoning models and local non-thinking models.
+
+## Qwen3-Coder-Next
+
+[Qwen3-Coder-Next](https://huggingface.co/Qwen/Qwen3-Coder-Next) is a recommended local model for this repository's source-analysis workflow.
+
+The published model card describes it as an Apache-2.0 open-weight coding-agent model with:
+
+- 80 billion total parameters and 3 billion activated parameters
+- a native context length of 262,144 tokens
+- tool-calling and agentic coding support
+- non-thinking mode only
+
+The project agent definitions therefore do not set `thinking`. Provider-specific reasoning controls belong in the user's Pi model configuration instead.
+
+## Local OpenAI-compatible endpoint
+
+Pi loads custom providers from `~/.pi/agent/models.json`. The following example targets a local OpenAI-compatible endpoint, such as vLLM or SGLang:
+
+```json
+{
+  "providers": {
+    "local-qwen": {
+      "baseUrl": "http://localhost:8000/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "compat": {
+        "supportsReasoningEffort": false
+      },
+      "models": [
+        {
+          "id": "Qwen/Qwen3-Coder-Next",
+          "name": "Qwen3-Coder-Next (Local)",
+          "reasoning": false,
+          "contextWindow": 32768,
+          "maxTokens": 16384,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+The example intentionally starts with a 32,768-token context window. The model supports a larger native context, but the model card recommends reducing the context length when the inference server runs out of memory.
+
+If the local endpoint rejects the `developer` role, also add:
+
+```json
+"supportsDeveloperRole": false
+```
+
+under the provider's `compat` object.
+
+See the [Pi custom model documentation](https://pi.dev/docs/latest/models) for all provider and compatibility options.
+
+## Selecting the model for subagents
+
+Select the model interactively with `/model`, or set a user-level default in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "subagents": {
+    "defaultModel": "local-qwen/Qwen/Qwen3-Coder-Next"
+  }
+}
+```
+
+Use the exact provider and model identifier shown by Pi if the local configuration uses a different provider name or served model name.
+
+For an individual run, `pi-subagents` also supports a per-run model override. This can be useful for running the final evidence review with a different model while keeping Qwen3-Coder-Next for source scouting and research.

--- a/.pi/agents/okf-crossplane-researcher.md
+++ b/.pi/agents/okf-crossplane-researcher.md
@@ -2,7 +2,6 @@
 name: okf-crossplane-researcher
 description: Read-only Crossplane researcher for source-backed OKF concepts, APIs, documentation, and examples.
 tools: read, grep, find, ls, bash
-thinking: medium
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/.pi/agents/okf-reviewer.md
+++ b/.pi/agents/okf-reviewer.md
@@ -2,7 +2,6 @@
 name: okf-reviewer
 description: Read-only evidence and conformance reviewer for changed OKF documents and their claim ledgers.
 tools: read, grep, find, ls, bash
-thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/.pi/agents/okf-source-scout.md
+++ b/.pi/agents/okf-source-scout.md
@@ -2,7 +2,6 @@
 name: okf-source-scout
 description: Fast, read-only inventory agent for classifying OKF sources and locating high-signal files.
 tools: read, grep, find, ls, bash
-thinking: low
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false

--- a/.pi/agents/okf-upjet-researcher.md
+++ b/.pi/agents/okf-upjet-researcher.md
@@ -2,7 +2,6 @@
 name: okf-upjet-researcher
 description: Read-only specialist for evidence-backed Upjet, Crossplane, and Terraform resource mappings.
 tools: read, grep, find, ls, bash
-thinking: high
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false


### PR DESCRIPTION
## Summary

- remove explicit `thinking` levels from all project-local Pi agents
- keep provider, model, and reasoning configuration outside the repository
- document Qwen3-Coder-Next as a recommended local model for source analysis
- add a `~/.pi/agent/models.json` example for a local OpenAI-compatible endpoint
- update the shared OKF skill model policy and bump it to version 1.3

## Why

Qwen3-Coder-Next supports non-thinking mode only. The Pi agents previously declared `thinking: low`, `medium`, or `high` in their frontmatter. Those fixed values coupled the project agents to providers that expose compatible reasoning controls and could prevent a non-thinking local model from being used cleanly.

The Pi agents now inherit the selected session model and its supported capabilities without imposing a reasoning level.

## Qwen3-Coder-Next guidance

The new `.pi/README.md` documents:

- the model's Apache-2.0 license
- 80B total and 3B activated parameters
- its native 262,144-token context window
- tool-calling and agentic coding support
- its non-thinking-only behavior
- a conservative 32,768-token local context configuration
- an example for vLLM, SGLang, or another OpenAI-compatible endpoint
- optional selection through `pi-subagents.defaultModel`

Sources:

- https://huggingface.co/Qwen/Qwen3-Coder-Next
- https://pi.dev/docs/latest/models
- https://github.com/nicobailon/pi-subagents

## Portability

The repository still does not pin Qwen3-Coder-Next or any other provider-specific model. Hosted reasoning models and local non-thinking models can use the same `okf-*` agents. A different model can still be selected for ambiguous Upjet mappings or the final evidence review.

## Validation

- branch is based on `main` after merged PR #3
- all four `.pi/agents/okf-*.md` files no longer contain a `thinking` field
- existing tool allowlists, turn budgets, fresh context, and `maxSubagentDepth: 0` remain unchanged
- JSON examples in `.pi/README.md` are syntactically valid
- six files are changed

A full Pi runtime execution was not performed because no local Pi and Qwen3-Coder-Next inference endpoint is available in this execution environment.
