### PR TITLE
Define reviewed publication and feature maturity rules

### DIFF
--- a/.agents/agents/okf-crossplane-core-code-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-code-researcher/AGENT.md
@@ -23,7 +23,7 @@ For every relevant CRD record:
 - group, served version, storage version, kind, plural name, and scope
 - explicit `deprecated` and `deprecationWarning` values
 - required fields, defaults, enums, validation rules, references, status fields, and printer columns that materially affect users
-- feature gates, lifecycle annotations, or maturity statements only when directly present in source
+- feature gates, lifecycle annotations, and maturity statements
 
 ## Legacy-free gate
 
@@ -36,8 +36,11 @@ For every relevant CRD record:
 
 - CRDs establish served API shape, defaults, validation, scope, and deprecation state.
 - CRDs do not by themselves establish recommended workflows.
-- Record Alpha, Beta, Preview, or Deprecated only with direct evidence. Otherwise record Stable by repository default.
-- Never infer feature state from `v1alpha1`, `v1beta1`, or `v1`.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels when present.
+- When no explicit label exists, classify a served `v1alpha*` API as Alpha and a served `v1beta*` API as Beta. Never classify either as Stable.
+- For APIs without a served alpha or beta version, use Stable by repository default unless another selected source explicitly states a non-stable feature state.
+- Never use `v1` alone as evidence of Stable; it only permits the Stable default when no other evidence indicates a non-stable state.
+- When an explicit Stable label conflicts with a served alpha or beta version, use Alpha or Beta for the API and report the conflict.
 - When CRDs and official documentation differ, report the conflict and preserve both version scopes.
 - Treat generated CRDs as authoritative release artifacts while identifying their generator or Go type source when it is needed to explain a field.
 

--- a/.agents/agents/okf-crossplane-core-code-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-code-researcher/AGENT.md
@@ -35,8 +35,9 @@ For every relevant CRD record:
 ## Evidence rules
 
 - CRDs establish served API shape, defaults, validation, scope, and deprecation state.
-- CRDs do not by themselves establish recommended workflows or feature maturity unless they state it explicitly.
-- Record Alpha, Beta, or Stable only with direct evidence. Otherwise report `Not stated by the selected CRD source` and let the documentation researcher resolve it.
+- CRDs do not by themselves establish recommended workflows.
+- Record Alpha, Beta, Preview, or Deprecated only with direct evidence. Otherwise record Stable by repository default.
+- Never infer feature state from `v1alpha1`, `v1beta1`, or `v1`.
 - When CRDs and official documentation differ, report the conflict and preserve both version scopes.
 - Treat generated CRDs as authoritative release artifacts while identifying their generator or Go type source when it is needed to explain a field.
 

--- a/.agents/agents/okf-crossplane-core-docs-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-docs-researcher/AGENT.md
@@ -31,8 +31,10 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 ## Evidence rules
 
 - Documentation establishes terminology, recommended workflows, installation guidance, and user-facing examples; it does not override CRDs for served API shape.
-- Record Alpha, Beta, Preview, or Deprecated only when the selected documentation states that feature state directly, and include a citation. Otherwise record Stable by repository default.
-- Never infer maturity from an API suffix such as `v1alpha1`, `v1beta1`, or `v1`.
+- Preserve Alpha, Beta, Preview, Stable, or Deprecated when the selected documentation states the feature state directly, and include a citation.
+- When documentation has no explicit feature-state label, report the Stable repository default as provisional and require the parent agent to apply the served API version ceiling from code or CRD evidence.
+- A relevant served `v1alpha*` API must be classified as Alpha and a relevant served `v1beta*` API must be classified as Beta, even when documentation is silent or calls it Stable. Record such conflicts explicitly.
+- Never use `v1` alone as proof of Stable.
 - Separate general provider and function installation guidance from details of a specific provider or function implementation.
 - Record documentation conflicts, stale examples, redirects, and version boundaries explicitly.
 - Deduplicate repeated guidance and return only the minimum evidence needed for each concept candidate.

--- a/.agents/agents/okf-crossplane-core-docs-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-docs-researcher/AGENT.md
@@ -31,7 +31,8 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 ## Evidence rules
 
 - Documentation establishes terminology, recommended workflows, installation guidance, and user-facing examples; it does not override CRDs for served API shape.
-- Record the exact feature state stated by the source, such as Alpha, Beta, or Stable. Include a direct citation. When the source does not state a feature state, report `Not stated by the selected documentation`; never infer maturity from an API suffix such as `v1alpha1` or `v1beta1`.
+- Record Alpha, Beta, Preview, or Deprecated only when the selected documentation states that feature state directly, and include a citation. Otherwise record Stable by repository default.
+- Never infer maturity from an API suffix such as `v1alpha1`, `v1beta1`, or `v1`.
 - Separate general provider and function installation guidance from details of a specific provider or function implementation.
 - Record documentation conflicts, stale examples, redirects, and version boundaries explicitly.
 - Deduplicate repeated guidance and return only the minimum evidence needed for each concept candidate.

--- a/.agents/agents/okf-crossplane-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-researcher/AGENT.md
@@ -20,7 +20,8 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 - Restrict third-party research to configured paths and corroborate reusable patterns with primary sources or official documentation.
 - Separate API shape, runtime behavior, documented guidance, and illustrative examples into distinct concept candidates.
 - Record version boundaries and feature gates when the source makes them explicit.
-- Never infer Alpha, Beta, or Stable from an API version suffix. Report `Not stated by selected sources` when no direct feature-state evidence exists.
+- Record Alpha, Beta, Preview, or Deprecated only with direct evidence. Otherwise record Stable by repository default.
+- Never infer feature state from an API version suffix such as `v1alpha1`, `v1beta1`, or `v1`.
 - For providers, inspect package metadata, ProviderConfig/authentication APIs, managed-resource schemas, controllers, tests, and examples.
 - For Crossplane CLI and testing tools, identify commands, accepted inputs, outputs, and validation behavior from implementation and tests.
 - Report licensing information before proposing copied or adapted third-party material. Otherwise summarize and cite.

--- a/.agents/agents/okf-crossplane-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-researcher/AGENT.md
@@ -20,8 +20,11 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 - Restrict third-party research to configured paths and corroborate reusable patterns with primary sources or official documentation.
 - Separate API shape, runtime behavior, documented guidance, and illustrative examples into distinct concept candidates.
 - Record version boundaries and feature gates when the source makes them explicit.
-- Record Alpha, Beta, Preview, or Deprecated only with direct evidence. Otherwise record Stable by repository default.
-- Never infer feature state from an API version suffix such as `v1alpha1`, `v1beta1`, or `v1`.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from selected sources.
+- Without an explicit label, classify a served `v1alpha*` API as Alpha and a served `v1beta*` API as Beta. Never classify either as Stable.
+- For APIs without a served alpha or beta version, use Stable by repository default unless another selected source explicitly states a non-stable feature state.
+- Never use `v1` alone as proof of Stable.
+- When an explicit Stable label conflicts with a served alpha or beta API version, use Alpha or Beta for the API and report the conflict.
 - For providers, inspect package metadata, ProviderConfig/authentication APIs, managed-resource schemas, controllers, tests, and examples.
 - For Crossplane CLI and testing tools, identify commands, accepted inputs, outputs, and validation behavior from implementation and tests.
 - Report licensing information before proposing copied or adapted third-party material. Otherwise summarize and cite.

--- a/.agents/agents/okf-function-go-templating-researcher/AGENT.md
+++ b/.agents/agents/okf-function-go-templating-researcher/AGENT.md
@@ -57,7 +57,8 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 - Delegate human-authored issue and pull-request research to `okf-function-go-templating-project-history-researcher` after reporting the selected and previous stable tags, commits, release date, and identified capability areas.
 - Build capability concepts instead of creating one catalog page per example file, issue, or pull request.
 - Record all required companion files and assumptions for examples.
-- Record feature state only when the repository or matching official Crossplane documentation states Alpha, Beta, Stable, or Deprecated directly. Otherwise report `Not stated by the selected sources`; never infer maturity from `v1alpha1`, `v1beta1`, or `v1`.
+- Record Alpha, Beta, Preview, or Deprecated only when the repository or matching official Crossplane documentation states it directly. Otherwise record Stable by repository default.
+- Never infer feature state from `v1alpha1`, `v1beta1`, or `v1`.
 - Verify the repository license before proposing copied or adapted material. Otherwise summarize and cite.
 
 Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.

--- a/.agents/agents/okf-function-go-templating-researcher/AGENT.md
+++ b/.agents/agents/okf-function-go-templating-researcher/AGENT.md
@@ -57,8 +57,11 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 - Delegate human-authored issue and pull-request research to `okf-function-go-templating-project-history-researcher` after reporting the selected and previous stable tags, commits, release date, and identified capability areas.
 - Build capability concepts instead of creating one catalog page per example file, issue, or pull request.
 - Record all required companion files and assumptions for examples.
-- Record Alpha, Beta, Preview, or Deprecated only when the repository or matching official Crossplane documentation states it directly. Otherwise record Stable by repository default.
-- Never infer feature state from `v1alpha1`, `v1beta1`, or `v1`.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from the repository or matching official Crossplane documentation.
+- Without an explicit label, classify a served `v1alpha*` function input API as Alpha and a served `v1beta*` function input API as Beta. Never classify either as Stable.
+- For function capabilities without a relevant served alpha or beta API, use Stable by repository default unless another selected source explicitly states a non-stable feature state.
+- Never use `v1` alone as proof of Stable.
+- When an explicit Stable label conflicts with a served alpha or beta API version, use Alpha or Beta for the API and record the conflict.
 - Verify the repository license before proposing copied or adapted material. Otherwise summarize and cite.
 
 Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.

--- a/.agents/agents/okf-reviewer/AGENT.md
+++ b/.agents/agents/okf-reviewer/AGENT.md
@@ -9,7 +9,7 @@ Review only the changed OKF documents and their evidence packets. Do not edit fi
 3. Source roles remain explicit: implementation, official documentation, supporting source, project history, and third-party example evidence are not treated as interchangeable.
 4. Crossplane Core research resolves the latest stable Crossplane release first and uses the matching stable documentation major.minor series instead of `master`.
 5. Official documentation claims include the applicable Crossplane version scope and conflicts with implementation are disclosed.
-6. Every feature-state value is directly supported by a citation. API versions such as `v1alpha1`, `v1beta1`, and `v1` are not accepted as maturity evidence. Missing maturity is written as `Not stated by selected sources`.
+6. Alpha, Beta, Preview, and Deprecated feature states are directly supported by citations. Features without one of these explicit labels are recorded as Stable. API versions such as `v1alpha1`, `v1beta1`, and `v1` are not accepted as maturity evidence.
 7. Legacy-free concepts contain no Claims, claim references, deprecated CompositeResourceDefinition v1 schema, legacy v1 XR semantics, or sections explicitly labelled `v1 Composite Resources (Legacy)`.
 8. Current APIs are not removed merely because their Kubernetes API version ends in `/v1`; explicit deprecation metadata or a legacy label is required. Review current `Composition` evidence separately from deprecated XRD v1 evidence.
 9. Crossplane CLI concepts and CLI source evidence are not presented as Crossplane Core.
@@ -28,7 +28,8 @@ Review only the changed OKF documents and their evidence packets. Do not edit fi
 22. OKF reserved files and frontmatter follow the profile in `.agents/skills/okf/references/okf-profile.md`.
 23. Examples are copied, adapted, or summarized accurately, and that distinction is disclosed.
 24. The complete pending change set is on a dedicated non-default branch and includes every related catalog document, source lock, claim ledger, index, log, and required agent or source-profile change.
+25. `mise run lint` succeeds after the final fixes and before the root or parent agent creates a commit.
 
 Use shell commands only for read-only validation and inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
 
-Review the complete pending change set before the root or parent agent commits it. Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains. Approval is the gate for the root or parent agent to commit all intended changes and open a pull request.
+Review the complete pending change set before the root or parent agent commits it. Run `mise run lint` as the final validation command. Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains and lint succeeds. Approval is the gate for the root or parent agent to commit all intended changes and open a pull request.

--- a/.agents/agents/okf-reviewer/AGENT.md
+++ b/.agents/agents/okf-reviewer/AGENT.md
@@ -27,7 +27,8 @@ Review only the changed OKF documents and their evidence packets. Do not edit fi
 21. Concepts are small, non-duplicative, correctly linked, and placed at the right level of the catalog.
 22. OKF reserved files and frontmatter follow the profile in `.agents/skills/okf/references/okf-profile.md`.
 23. Examples are copied, adapted, or summarized accurately, and that distinction is disclosed.
+24. The complete pending change set is on a dedicated non-default branch and includes every related catalog document, source lock, claim ledger, index, log, and required agent or source-profile change.
 
 Use shell commands only for read-only validation and inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
 
-Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains.
+Review the complete pending change set before the root or parent agent commits it. Return findings ordered by severity with file paths and evidence. Return `APPROVED` only when no blocking finding remains. Approval is the gate for the root or parent agent to commit all intended changes and open a pull request.

--- a/.agents/agents/okf-reviewer/AGENT.md
+++ b/.agents/agents/okf-reviewer/AGENT.md
@@ -9,7 +9,7 @@ Review only the changed OKF documents and their evidence packets. Do not edit fi
 3. Source roles remain explicit: implementation, official documentation, supporting source, project history, and third-party example evidence are not treated as interchangeable.
 4. Crossplane Core research resolves the latest stable Crossplane release first and uses the matching stable documentation major.minor series instead of `master`.
 5. Official documentation claims include the applicable Crossplane version scope and conflicts with implementation are disclosed.
-6. Alpha, Beta, Preview, and Deprecated feature states are directly supported by citations. Features without one of these explicit labels are recorded as Stable. API versions such as `v1alpha1`, `v1beta1`, and `v1` are not accepted as maturity evidence.
+6. Explicit Alpha, Beta, Preview, Stable, and Deprecated labels are preserved. Without an explicit label, served `v1alpha*` APIs are Alpha and served `v1beta*` APIs are Beta; neither may be recorded as Stable. Other APIs default to Stable only when no selected source or served API version indicates a non-stable state. `v1` alone is not proof of Stable.
 7. Legacy-free concepts contain no Claims, claim references, deprecated CompositeResourceDefinition v1 schema, legacy v1 XR semantics, or sections explicitly labelled `v1 Composite Resources (Legacy)`.
 8. Current APIs are not removed merely because their Kubernetes API version ends in `/v1`; explicit deprecation metadata or a legacy label is required. Review current `Composition` evidence separately from deprecated XRD v1 evidence.
 9. Crossplane CLI concepts and CLI source evidence are not presented as Crossplane Core.

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -3,7 +3,7 @@ name: okf
 description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, and examples. Never invoke implicitly; the user must invoke `$okf`, `/skill:okf`, or `/okf`.
 disable-model-invocation: true
 metadata:
-  version: "1.3"
+  version: "1.4"
   license: Apache-2.0
 ---
 
@@ -42,6 +42,15 @@ The workflow and evidence contracts are shared across agent runtimes:
 - Runtime-specific agents use the same `okf-*` role names and must preserve the same read-only evidence contract.
 - Every dedicated role must exist as a matching Codex and Pi agent set.
 - The root or parent agent remains the only writer regardless of runtime.
+
+## Change publication rules
+
+- For every content addition or update, create a dedicated non-default branch from the latest default branch before editing.
+- Keep the complete related change set on that branch, including generated content and all supporting source locks, claim ledgers, indexes, logs, agent instructions, and source profiles.
+- Complete deterministic validation and obtain `APPROVED` from `okf-reviewer` before committing.
+- After all review fixes, run `mise run lint`. Fix every lint error and rerun the command until it succeeds.
+- Commit every intended file only after reviewer approval and a successful lint run. Push the branch and open a pull request.
+- Do not merge the pull request unless the user explicitly requests it.
 
 ## Workflow
 
@@ -105,7 +114,7 @@ Use evidence according to its source role:
 - Project-history sources establish that a human-authored issue was reported, a pull request was proposed, or a change was merged. They do not independently establish released behavior, API shape, lifecycle state, or recommendations.
 - Third-party examples are illustrative. They may establish what that repository implements, but they must not be the sole evidence for Crossplane API semantics, runtime behavior, compatibility, security properties, or recommended practices.
 
-Never infer Alpha, Beta, or Stable from an API version suffix. Use direct feature-state evidence or state `Not stated by selected sources`.
+Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require direct source evidence for every non-stable label. Never infer feature state from API version suffixes such as `v1alpha1`, `v1beta1`, or `v1`.
 
 Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or an explicit legacy label.
 
@@ -134,7 +143,7 @@ Before writing Markdown, reduce the evidence packets to a claim ledger:
 - supporting immutable citation or direct issue/PR snapshot
 - confidence: direct, corroborated, or inferred
 - Crossplane release or documentation series
-- feature state and its evidence, or `Not stated by selected sources`
+- feature state and basis: direct citation for Alpha, Beta, Preview, or Deprecated; otherwise Stable by repository default because selected sources contain no explicit non-stable label
 - selected-release relationship for issue and pull-request evidence
 - research timestamp for project-history evidence
 - legacy exclusions applied
@@ -196,7 +205,8 @@ Also check:
 - no concept contains unresolved placeholders presented as facts
 - Core concepts record the selected stable release and matching documentation series
 - function concepts record the dynamically selected stable function tag and commit
-- feature states have direct evidence and are not inferred from API version names
+- Alpha, Beta, Preview, and Deprecated states have direct evidence; features without an explicit non-stable label are Stable by repository default
+- feature state is not inferred from API version names
 - legacy-free output excludes Claims, deprecated XRD v1, legacy v1 XR semantics, and explicitly labelled legacy sections
 - current non-deprecated APIs are not excluded only because they use `/v1`
 - Crossplane CLI content is not categorized as Core
@@ -216,7 +226,7 @@ Use an installed OKF linter when available, but do not add or install dependenci
 
 After deterministic validation passes, use `okf-reviewer` on the changed concepts and their claim ledger. Do not invoke the reviewer while blocking validation errors remain.
 
-Fix blocking findings as the root or parent agent, rerun targeted validation, and report remaining warnings explicitly.
+Fix blocking findings as the root or parent agent and rerun targeted validation. After all fixes, run `mise run lint` and fix every reported issue. The reviewer may return `APPROVED` only after the final lint run succeeds. Commit only after approval.
 
 ## Token and model policy
 
@@ -254,10 +264,10 @@ Report:
 - selected Crossplane release and documentation series for Core work
 - selected stable function tags and commits
 - source roles used for material claims
-- feature-state evidence or `Not stated by selected sources`
+- feature-state citations for Alpha, Beta, Preview, or Deprecated labels, or the Stable-by-default basis
 - legacy material excluded
 - project-history timestamp, human-authored items summarized, and bot/app activity excluded
-- validation results
+- deterministic validation and `mise run lint` results
 - reviewer status
 - unresolved mappings, conflicts, licensing questions, and permitted broken links
 - the narrowest next source batch, when more coverage is requested

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -114,7 +114,13 @@ Use evidence according to its source role:
 - Project-history sources establish that a human-authored issue was reported, a pull request was proposed, or a change was merged. They do not independently establish released behavior, API shape, lifecycle state, or recommendations.
 - Third-party examples are illustrative. They may establish what that repository implements, but they must not be the sole evidence for Crossplane API semantics, runtime behavior, compatibility, security properties, or recommended practices.
 
-Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require direct source evidence for every non-stable label. Never infer feature state from API version suffixes such as `v1alpha1`, `v1beta1`, or `v1`.
+Apply feature-state precedence:
+
+1. Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from selected sources.
+2. A relevant served `v1alpha*` API is an Alpha stability ceiling and a relevant served `v1beta*` API is a Beta stability ceiling. Never record either as Stable.
+3. When an explicit Stable label conflicts with a served alpha or beta API, classify the API as Alpha or Beta and record the source conflict.
+4. When no explicit label exists, use Alpha for `v1alpha*`, Beta for `v1beta*`, and Stable only when no relevant served alpha or beta API exists.
+5. Never use `v1` alone as proof of Stable; it only permits the repository Stable default when no other selected evidence indicates a non-stable state.
 
 Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or an explicit legacy label.
 
@@ -143,7 +149,7 @@ Before writing Markdown, reduce the evidence packets to a claim ledger:
 - supporting immutable citation or direct issue/PR snapshot
 - confidence: direct, corroborated, or inferred
 - Crossplane release or documentation series
-- feature state and basis: direct citation for Alpha, Beta, Preview, or Deprecated; otherwise Stable by repository default because selected sources contain no explicit non-stable label
+- feature state and basis: explicit label, served alpha or beta API ceiling, or Stable repository default when no non-stable evidence exists
 - selected-release relationship for issue and pull-request evidence
 - research timestamp for project-history evidence
 - legacy exclusions applied
@@ -205,8 +211,11 @@ Also check:
 - no concept contains unresolved placeholders presented as facts
 - Core concepts record the selected stable release and matching documentation series
 - function concepts record the dynamically selected stable function tag and commit
-- Alpha, Beta, Preview, and Deprecated states have direct evidence; features without an explicit non-stable label are Stable by repository default
-- feature state is not inferred from API version names
+- explicit feature-state labels are preserved
+- served `v1alpha*` APIs are never recorded above Alpha and served `v1beta*` APIs are never recorded above Beta
+- an explicit Stable label that conflicts with a served alpha or beta API is recorded as a conflict, not accepted as Stable
+- `v1` alone is not used as proof of Stable
+- Stable is used by repository default only when no selected source or relevant served API indicates a non-stable state
 - legacy-free output excludes Claims, deprecated XRD v1, legacy v1 XR semantics, and explicitly labelled legacy sections
 - current non-deprecated APIs are not excluded only because they use `/v1`
 - Crossplane CLI content is not categorized as Core
@@ -264,7 +273,7 @@ Report:
 - selected Crossplane release and documentation series for Core work
 - selected stable function tags and commits
 - source roles used for material claims
-- feature-state citations for Alpha, Beta, Preview, or Deprecated labels, or the Stable-by-default basis
+- explicit feature-state citations, served alpha or beta API ceilings, or the Stable repository-default basis
 - legacy material excluded
 - project-history timestamp, human-authored items summarized, and bot/app activity excluded
 - deterministic validation and `mise run lint` results

--- a/.agents/skills/okf/references/evidence-contract.md
+++ b/.agents/skills/okf/references/evidence-contract.md
@@ -20,8 +20,8 @@ Use this compact Markdown structure:
 - Title: proposed title
 - Summary: one sentence, source-backed
 - Crossplane version scope: exact release or major.minor documentation series
-- Feature state: Alpha | Beta | Stable | Deprecated | Not stated by selected sources
-- Feature-state evidence: commit-pinned citation or `not stated`
+- Feature state: Alpha | Beta | Preview | Stable | Deprecated
+- Feature-state basis: direct commit-pinned citation for Alpha, Beta, Preview, or Deprecated; otherwise `Stable by repository default because selected sources contain no explicit non-stable label`
 - Claims:
   - Claim text
     - Class: API | behavior | documented-guidance | release-history | reported-limitation | proposal | illustrative-pattern
@@ -64,7 +64,8 @@ Rules:
 - Primary sources establish API shape and runtime behavior.
 - Official documentation establishes documented guidance and user-facing terminology. Record version scope and conflicts with implementation.
 - Resolve the latest stable Crossplane release before researching Crossplane Core unless the user explicitly requests another release or preview content.
-- Never infer Alpha, Beta, or Stable from API version names such as `v1alpha1`, `v1beta1`, or `v1`. Cite an explicit feature-state statement or use `Not stated by selected sources`.
+- Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require a direct citation for every non-stable label.
+- Never infer feature state from API version names such as `v1alpha1`, `v1beta1`, or `v1`.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label. Current Crossplane v2 resources may still use a v1 Kubernetes API version.
 - Exclude Claims, deprecated CompositeResourceDefinition v1, and legacy v1 composite-resource semantics from legacy-free catalog work.
 - Project-history evidence must record the research timestamp because issue and pull-request state can change.

--- a/.agents/skills/okf/references/evidence-contract.md
+++ b/.agents/skills/okf/references/evidence-contract.md
@@ -21,7 +21,7 @@ Use this compact Markdown structure:
 - Summary: one sentence, source-backed
 - Crossplane version scope: exact release or major.minor documentation series
 - Feature state: Alpha | Beta | Preview | Stable | Deprecated
-- Feature-state basis: direct commit-pinned citation for Alpha, Beta, Preview, or Deprecated; otherwise `Stable by repository default because selected sources contain no explicit non-stable label`
+- Feature-state basis: explicit commit-pinned label; served `v1alpha*` or `v1beta*` API version; or `Stable by repository default because selected sources contain no explicit non-stable label and no relevant served alpha or beta API version`
 - Claims:
   - Claim text
     - Class: API | behavior | documented-guidance | release-history | reported-limitation | proposal | illustrative-pattern
@@ -64,8 +64,11 @@ Rules:
 - Primary sources establish API shape and runtime behavior.
 - Official documentation establishes documented guidance and user-facing terminology. Record version scope and conflicts with implementation.
 - Resolve the latest stable Crossplane release before researching Crossplane Core unless the user explicitly requests another release or preview content.
-- Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require a direct citation for every non-stable label.
-- Never infer feature state from API version names such as `v1alpha1`, `v1beta1`, or `v1`.
+- Preserve explicit Alpha, Beta, Preview, Stable, and Deprecated labels from selected sources.
+- A relevant served `v1alpha*` API is an Alpha stability ceiling and a relevant served `v1beta*` API is a Beta stability ceiling. Never record either as Stable.
+- When an explicit Stable label conflicts with a served alpha or beta API version, classify the API as Alpha or Beta and record the source conflict.
+- When no explicit label exists, use Alpha for `v1alpha*`, Beta for `v1beta*`, and Stable only when no relevant served alpha or beta API version exists.
+- Never use `v1` alone as evidence of Stable; it only permits the repository Stable default when no other selected evidence indicates a non-stable state.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label. Current Crossplane v2 resources may still use a v1 Kubernetes API version.
 - Exclude Claims, deprecated CompositeResourceDefinition v1, and legacy v1 composite-resource semantics from legacy-free catalog work.
 - Project-history evidence must record the research timestamp because issue and pull-request state can change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Keep the complete related change set on that branch, including catalog documents, source locks, claim ledgers, indexes, logs, and required agent or source-profile changes.
 - Run deterministic validation and the `okf-reviewer` before committing the changes.
 - Resolve all blocking review findings and rerun targeted validation. Continue only after the reviewer returns `APPROVED`.
-- After approval, commit every intended change. Do not leave generated or supporting files uncommitted.
+- After the final review fixes, run `mise run lint` before creating any commit. Fix every lint error and rerun the command until it succeeds.
+- After reviewer approval and a successful lint run, commit every intended change. Do not leave generated or supporting files uncommitted.
 - Push the branch and open a pull request for the reviewed commit set. Do not merge the pull request unless the user explicitly requests it.
 
 ## Domain routing
@@ -43,7 +44,8 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use official Crossplane documentation to establish documented terminology, guidance, supported workflows, lifecycle states, and versioned user-facing examples.
 - Resolve the latest stable Crossplane release before Core research and use the matching stable documentation major.minor series.
 - Resolve the highest stable semantic-version tag before researching a composition function. Do not assume a sample tag and do not silently fall back to `main`.
-- Record Alpha, Beta, Stable, or Deprecated only with direct source evidence. Never infer feature maturity from API version names.
+- Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require direct source evidence for every non-stable label.
+- Never infer feature maturity from API version names such as `v1alpha1`, `v1beta1`, or `v1`.
 - Exclude Claims, claim references, deprecated CompositeResourceDefinition v1, legacy v1 XR semantics, and sections explicitly labelled `v1 Composite Resources (Legacy)` from legacy-free output.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label.
 - Project-history evidence must exclude bots and apps and record a research timestamp.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,10 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use official Crossplane documentation to establish documented terminology, guidance, supported workflows, lifecycle states, and versioned user-facing examples.
 - Resolve the latest stable Crossplane release before Core research and use the matching stable documentation major.minor series.
 - Resolve the highest stable semantic-version tag before researching a composition function. Do not assume a sample tag and do not silently fall back to `main`.
-- Treat a feature as Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated. Require direct source evidence for every non-stable label.
-- Never infer feature maturity from API version names such as `v1alpha1`, `v1beta1`, or `v1`.
+- Record explicit Alpha, Beta, Preview, Stable, or Deprecated labels from selected sources when available.
+- Without an explicit feature-state label, treat a served `v1alpha*` API as Alpha and a served `v1beta*` API as Beta. Such APIs must never be recorded as Stable.
+- For APIs without an alpha or beta served version, default the feature state to Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated.
+- Never use `v1` alone as proof of Stable; it only permits the Stable default when no selected source or served API version indicates a non-stable state.
 - Exclude Claims, claim references, deprecated CompositeResourceDefinition v1, legacy v1 XR semantics, and sections explicitly labelled `v1 Composite Resources (Legacy)` from legacy-free output.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label.
 - Project-history evidence must exclude bots and apps and record a research timestamp.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,15 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use at most three direct subagents at once. Do not create nested subagent trees.
 - When running in Pi, use only the project agents whose names start with `okf-`. Their tool allowlists intentionally omit editing tools and nested delegation.
 
+## Change workflow
+
+- For every content addition or update, create a new dedicated branch from the latest default branch before editing. Never add or update content directly on the default branch.
+- Keep the complete related change set on that branch, including catalog documents, source locks, claim ledgers, indexes, logs, and required agent or source-profile changes.
+- Run deterministic validation and the `okf-reviewer` before committing the changes.
+- Resolve all blocking review findings and rerun targeted validation. Continue only after the reviewer returns `APPROVED`.
+- After approval, commit every intended change. Do not leave generated or supporting files uncommitted.
+- Push the branch and open a pull request for the reviewed commit set. Do not merge the pull request unless the user explicitly requests it.
+
 ## Domain routing
 
 - Use `okf-crossplane-core-docs-researcher` for current stable Crossplane Core documentation.


### PR DESCRIPTION
## What changed

- require every content addition or update to start on a dedicated non-default branch from the latest default branch
- require deterministic validation and `okf-reviewer` approval before committing
- require `mise run lint` after final review fixes and before any commit
- require every intended supporting file to be committed and published through a pull request
- define feature-state precedence across repository guidance, the shared OKF workflow, the evidence contract, the reviewer, and affected canonical researchers
- preserve explicit Alpha, Beta, Preview, Stable, and Deprecated labels
- treat served `v1alpha*` APIs as having an Alpha stability ceiling and served `v1beta*` APIs as having a Beta stability ceiling
- prevent alpha or beta APIs from being described as Stable, including when documentation contains a conflicting Stable label
- use the Stable repository default only when no selected source or relevant served API indicates a non-stable state
- clarify that `v1` alone is not proof of Stable
- keep runtime adapters unchanged because they reference the canonical instructions

## Why

The previous workflow assigned commit and pull-request ownership to the root agent, but it did not explicitly require a new branch, reviewer approval, lint execution before commits, or a complete committed change set. Feature maturity also defaulted to `Not stated by selected sources`, without the requested Stable default or an API-version ceiling preventing alpha and beta APIs from being classified as Stable.

## Validation

- reviewed the complete diff against `main`
- confirmed eight instruction and evidence-contract files changed
- confirmed runtime adapters were not duplicated
- confirmed the final rules consistently prevent served alpha and beta APIs from being classified as Stable
- no GitHub Actions workflow run or status check was associated with the final head
- `mise run lint` was not executed in this environment because a local repository checkout was unavailable

This pull request changes instructions and evidence policy only; it does not regenerate existing catalog content.