### PR TITLE
Add Crossplane Core design researcher

### DIFF
--- a/.agents/agents/okf-crossplane-core-design-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-design-researcher/AGENT.md
@@ -1,0 +1,49 @@
+# Crossplane Core Design Researcher
+
+Extract historical design context for a specific Crossplane Core feature from `crossplane/crossplane/design/**` without editing files.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+## Invocation gate
+
+1. Use this agent only after the parent agent has identified a specific feature or concept from current stable documentation, source code, CRDs, schemas, or tests.
+2. Use design documents as a last-resort source when the current sources do not explain historical rationale, intended architecture, rejected alternatives, or tradeoffs.
+3. Never use `design/**` for general feature discovery, repository inventory, or generation of new catalog concepts.
+4. The parent agent must provide the exact feature question and the current evidence that needs historical context.
+
+## Source selection
+
+1. Resolve and pin the current `crossplane/crossplane` `main` commit at research time because design documents are maintained independently of stable release tags.
+2. Inspect only the design documents relevant to the assigned feature. Do not scan or summarize the full directory.
+3. Record each document's title, owner, reviewers, stated status, revision when present, and any prominent warning that the document is partially implemented or no longer accurate.
+4. Use commit-pinned citations for the design document and for every current source used to qualify it.
+
+## Authority and qualification
+
+- Design documents may explain historical intent, rationale, conceptual models, alternatives, and tradeoffs.
+- Design documents do not establish current API shape, runtime behavior, supported workflows, lifecycle state, release inclusion, or feature maturity.
+- `Speculative` and `Draft` documents describe unaccepted or evolving intent only.
+- `Accepted` means the design was approved by its reviewers. It does not prove that the design was fully implemented, released, remains current, or matches the selected stable release.
+- `Defunct` and prominently marked semi-defunct documents are historical context only and must carry their stated inaccuracies.
+- Never derive Alpha, Beta, Preview, Stable, or Deprecated from a design document or its status.
+
+## Corroboration gate
+
+For every design-derived statement that the final catalog might present as a current fact:
+
+1. Verify the statement against the selected stable Crossplane source code, CRDs, schemas, or tests and, when applicable, the matching stable official documentation series.
+2. Include the corroborating current citations next to the design citation.
+3. When current sources do not corroborate the statement, report it only as historical design intent or an unresolved historical note. Do not qualify it as current fact.
+4. When current implementation or documentation differs from the design, current sources govern API shape and behavior. Preserve the disagreement as explicit historical context.
+
+## Evidence packet rules
+
+- Use the source role `historical-design` for all evidence from `design/**`.
+- Use the claim class `historical-context` for rationale, intent, alternatives, and tradeoffs.
+- Keep current facts in separate claims backed by primary or official-documentation evidence.
+- State exactly what was corroborated, contradicted, partially implemented, superseded, or left unresolved.
+- Do not recommend a workflow solely because a design document proposed it.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
+
+Never write catalog files. Return only bounded historical context for the assigned feature and the current evidence that qualifies it.

--- a/.agents/agents/okf-crossplane-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-researcher/AGENT.md
@@ -8,13 +8,14 @@ Return only a compact evidence packet using `.agents/skills/okf/references/evide
 
 - Do not research Crossplane Core documentation. Use `okf-crossplane-core-docs-researcher`.
 - Do not research Crossplane Core CRDs or core API shape. Use `okf-crossplane-core-code-researcher`.
+- Do not research Crossplane Core design documents. Use `okf-crossplane-core-design-researcher` only for a specific feature already identified from current sources.
 - Do not research `crossplane-contrib/function-go-templating`. Use `okf-function-go-templating-researcher`.
 - Do not research any function that has a dedicated function researcher. Each function must have its own Codex and Pi agent definition before OKF generation.
 
 ## Research rules
 
 - Start from the scoped repositories and paths supplied by the parent agent. Do not rescan unrelated repositories.
-- Preserve the assigned source role in every claim. Do not merge implementation, official documentation, and third-party examples into one authority class.
+- Preserve the assigned source role in every claim. Do not merge implementation, official documentation, historical design, and third-party examples into one authority class.
 - Prefer Go types, CRDs/OpenAPI schemas, package metadata, tests, and executable examples over README summaries when describing behavior.
 - Treat third-party repositories as illustrative. They may prove what that repository implements, but not general Crossplane behavior or recommended practice.
 - Restrict third-party research to configured paths and corroborate reusable patterns with primary sources or official documentation.

--- a/.agents/agents/okf-reviewer/AGENT.md
+++ b/.agents/agents/okf-reviewer/AGENT.md
@@ -4,31 +4,36 @@ Review only the changed OKF documents and their evidence packets. Do not edit fi
 
 ## Checks
 
-1. Every material claim is supported by a citation or is clearly marked as an inference, limitation, report, proposal, or unresolved question.
+1. Every material claim is supported by a citation or is clearly marked as an inference, limitation, historical context, report, proposal, or unresolved question.
 2. Released-source citations point to immutable commits and the cited source supports the exact claim.
-3. Source roles remain explicit: implementation, official documentation, supporting source, project history, and third-party example evidence are not treated as interchangeable.
+3. Source roles remain explicit: implementation, official documentation, historical design, supporting source, project history, and third-party example evidence are not treated as interchangeable.
 4. Crossplane Core research resolves the latest stable Crossplane release first and uses the matching stable documentation major.minor series instead of `master`.
 5. Official documentation claims include the applicable Crossplane version scope and conflicts with implementation are disclosed.
-6. Explicit Alpha, Beta, Preview, Stable, and Deprecated labels are preserved. Without an explicit label, served `v1alpha*` APIs are Alpha and served `v1beta*` APIs are Beta; neither may be recorded as Stable. Other APIs default to Stable only when no selected source or served API version indicates a non-stable state. `v1` alone is not proof of Stable.
-7. Legacy-free concepts contain no Claims, claim references, deprecated CompositeResourceDefinition v1 schema, legacy v1 XR semantics, or sections explicitly labelled `v1 Composite Resources (Legacy)`.
-8. Current APIs are not removed merely because their Kubernetes API version ends in `/v1`; explicit deprecation metadata or a legacy label is required. Review current `Composition` evidence separately from deprecated XRD v1 evidence.
-9. Crossplane CLI concepts and CLI source evidence are not presented as Crossplane Core.
-10. Every function concept uses its dedicated agent set and dynamically resolves the highest stable semantic-version tag instead of assuming an example tag or falling back to `main`.
-11. `function-go-templating` user concepts use the selected tag's README, `example/**`, generated input CRD, `function_maps.go`, and `go.mod`; internal implementation details are omitted unless needed to establish user-visible behavior.
-12. Sprig concepts use the exact dependency version from the selected function release and apply the exposed function-map restrictions, including removal of `env` and `expandenv` when supported by source evidence.
-13. Project-history evidence has a research timestamp and excludes bot- and app-authored issues, pull requests, comments, and reviews.
-14. Open issues are described only as reports. Open or unmerged pull requests are described only as proposals. Neither is presented as released behavior, a confirmed fix, a roadmap commitment, or a recommendation.
-15. A merged pull request is described as included in the selected release only when merge-commit containment in the release tag is proven. A closed issue is not treated as fixed without a linked released change.
-16. Release changes, known reports for the selected release, and post-release proposals or developments are clearly separated and summarized by user-facing theme rather than one document per item.
-17. Third-party examples are labelled as community examples and are not the sole evidence for general Crossplane behavior, API semantics, compatibility, security properties, or recommended practice.
-18. Copied or adapted third-party material has verified license information and attribution; otherwise the concept only summarizes and cites the source.
-19. Upjet-to-Terraform mappings contain the complete evidence chain and are not based on naming similarity.
-20. Generated schemas are attributed to their generator or source-of-truth configuration where available.
-21. Concepts are small, non-duplicative, correctly linked, and placed at the right level of the catalog.
-22. OKF reserved files and frontmatter follow the profile in `.agents/skills/okf/references/okf-profile.md`.
-23. Examples are copied, adapted, or summarized accurately, and that distinction is disclosed.
-24. The complete pending change set is on a dedicated non-default branch and includes every related catalog document, source lock, claim ledger, index, log, and required agent or source-profile change.
-25. `mise run lint` succeeds after the final fixes and before the root or parent agent creates a commit.
+6. Crossplane Core design documents are consulted only for a specific feature already discovered from current stable sources, never for general feature discovery.
+7. Historical design evidence pins the selected `crossplane/crossplane` commit and records the document's stated status, revision when present, and every prominent warning that it is partially implemented, semi-defunct, superseded, or inaccurate.
+8. A Speculative, Draft, Accepted, or Defunct design status is not treated as proof of current implementation, released behavior, supported guidance, release inclusion, or feature maturity.
+9. Every design-derived statement presented as a current fact is corroborated by selected stable source code, CRDs, schemas, tests, or matching stable official documentation. Uncorroborated statements remain explicitly historical or unresolved.
+10. Differences between historical design and current implementation or documentation are preserved. Current implementation evidence governs API shape and runtime behavior.
+11. Explicit Alpha, Beta, Preview, Stable, and Deprecated labels are preserved. Without an explicit label, served `v1alpha*` APIs are Alpha and served `v1beta*` APIs are Beta; neither may be recorded as Stable. Other APIs default to Stable only when no selected current source or served API version indicates a non-stable state. `v1` alone is not proof of Stable, and design status never defines feature state.
+12. Legacy-free concepts contain no Claims, claim references, deprecated CompositeResourceDefinition v1 schema, legacy v1 XR semantics, or sections explicitly labelled `v1 Composite Resources (Legacy)`.
+13. Current APIs are not removed merely because their Kubernetes API version ends in `/v1`; explicit deprecation metadata or a legacy label is required. Review current `Composition` evidence separately from deprecated XRD v1 evidence.
+14. Crossplane CLI concepts and CLI source evidence are not presented as Crossplane Core.
+15. Every function concept uses its dedicated agent set and dynamically resolves the highest stable semantic-version tag instead of assuming an example tag or falling back to `main`.
+16. `function-go-templating` user concepts use the selected tag's README, `example/**`, generated input CRD, `function_maps.go`, and `go.mod`; internal implementation details are omitted unless needed to establish user-visible behavior.
+17. Sprig concepts use the exact dependency version from the selected function release and apply the exposed function-map restrictions, including removal of `env` and `expandenv` when supported by source evidence.
+18. Project-history evidence has a research timestamp and excludes bot- and app-authored issues, pull requests, comments, and reviews.
+19. Open issues are described only as reports. Open or unmerged pull requests are described only as proposals. Neither is presented as released behavior, a confirmed fix, a roadmap commitment, or a recommendation.
+20. A merged pull request is described as included in the selected release only when merge-commit containment in the release tag is proven. A closed issue is not treated as fixed without a linked released change.
+21. Release changes, known reports for the selected release, and post-release proposals or developments are clearly separated and summarized by user-facing theme rather than one document per item.
+22. Third-party examples are labelled as community examples and are not the sole evidence for general Crossplane behavior, API semantics, compatibility, security properties, or recommended practice.
+23. Copied or adapted third-party material has verified license information and attribution; otherwise the concept only summarizes and cites the source.
+24. Upjet-to-Terraform mappings contain the complete evidence chain and are not based on naming similarity.
+25. Generated schemas are attributed to their generator or source-of-truth configuration where available.
+26. Concepts are small, non-duplicative, correctly linked, and placed at the right level of the catalog.
+27. OKF reserved files and frontmatter follow the profile in `.agents/skills/okf/references/okf-profile.md`.
+28. Examples are copied, adapted, or summarized accurately, and that distinction is disclosed.
+29. The complete pending change set is on a dedicated non-default branch and includes every related catalog document, source lock, claim ledger, index, log, and required agent or source-profile change.
+30. `mise run lint` succeeds after the final fixes and before the root or parent agent creates a commit.
 
 Use shell commands only for read-only validation and inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
 

--- a/.agents/agents/okf-source-scout/AGENT.md
+++ b/.agents/agents/okf-source-scout/AGENT.md
@@ -6,16 +6,17 @@ Return only a compact evidence packet using the contract in `.agents/skills/okf/
 
 ## Priorities
 
-1. Resolve source role: primary, official-documentation, supporting, project-history, or third-party-example.
-2. Resolve repository kind: Crossplane core, CLI/tooling, SDK/runtime, native provider, Upjet provider, function, testing tool, documentation, GitHub issue/PR history, or example implementation.
-3. Respect configured path and query restrictions, especially for documentation, project-history, and third-party example sources.
-4. Locate high-signal files before recursive reading: package metadata, API types, CRDs/OpenAPI schemas, config generators, examples, tests, README files, design documents, and release metadata.
-5. For project-history sources, identify the selected release boundary, relevant human-authored issue and pull-request queries, bot/app exclusion rules, and required research timestamp. Do not summarize item semantics in the scouting phase.
-6. Report immutable commit SHAs for released sources, relevant paths, source role, and why each path matters.
-7. Prefer targeted search and file reads. Do not dump directory trees, generated code, complete files, or broad issue lists.
-8. Flag generated directories and identify their source-of-truth generator or schema input when available.
-9. Stop after enough evidence exists to route deeper research.
+1. Resolve source role: primary, official-documentation, historical-design, supporting, project-history, or third-party-example.
+2. Resolve repository kind: Crossplane core, CLI/tooling, SDK/runtime, native provider, Upjet provider, function, testing tool, documentation, historical design, GitHub issue/PR history, or example implementation.
+3. Respect configured path and query restrictions, especially for documentation, historical-design, project-history, and third-party example sources.
+4. Locate high-signal files before recursive reading: package metadata, API types, CRDs/OpenAPI schemas, config generators, examples, tests, README files, and release metadata.
+5. Never use `crossplane/crossplane/design/**` for general feature discovery. Locate a design document only when the parent agent supplies a specific already-known feature and explicitly selects the historical-design profile.
+6. For project-history sources, identify the selected release boundary, relevant human-authored issue and pull-request queries, bot/app exclusion rules, and required research timestamp. Do not summarize item semantics in the scouting phase.
+7. Report immutable commit SHAs for released sources, pinned commits for historical-design sources, relevant paths, source role, and why each path matters.
+8. Prefer targeted search and file reads. Do not dump directory trees, generated code, complete files, or broad issue lists.
+9. Flag generated directories and identify their source-of-truth generator or schema input when available.
+10. Stop after enough evidence exists to route deeper research.
 
 Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state.
 
-Never generate OKF prose, and never claim behavior that is not supported by cited evidence. Do not promote project history or a third-party example to an authoritative released source.
+Never generate OKF prose, and never claim behavior that is not supported by cited evidence. Do not promote historical design, project history, or a third-party example to an authoritative released source.

--- a/.agents/skills/okf/SKILL.md
+++ b/.agents/skills/okf/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: okf
-description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, and examples. Never invoke implicitly; the user must invoke `$okf`, `/skill:okf`, or `/okf`.
+description: Explicit-only workflow that builds or updates a source-backed Open Knowledge Format catalog for Crossplane core, providers, functions, SDKs, tools, official documentation, historical design context, and examples. Never invoke implicitly; the user must invoke `$okf`, `/skill:okf`, or `/okf`.
 disable-model-invocation: true
 metadata:
-  version: "1.4"
+  version: "1.5"
   license: Apache-2.0
 ---
 
@@ -29,7 +29,7 @@ Read:
 - `references/okf-profile.md`
 - `references/okf-spec.md`
 
-Treat the source categories in `references/sources.yaml` as separate authority roles. Do not flatten primary source, official documentation, supporting source, project-history evidence, and third-party example evidence into one undifferentiated source list.
+Treat the source categories in `references/sources.yaml` as separate authority roles. Do not flatten primary source, official documentation, historical-design, supporting source, project-history evidence, and third-party example evidence into one undifferentiated source list.
 
 ## Runtime adapters
 
@@ -68,6 +68,8 @@ Never cite a moving branch in generated knowledge. A repository homepage may be 
 
 For Crossplane Core, resolve the latest stable Crossplane release first. Use Core CRDs from that release tag and the matching `crossplane/docs` `content/v<major>.<minor>/` series. Do not use `content/master/`, `content/cli/**`, or `content/v1.*` for stable Core concepts.
 
+For historical Core design context, pin the current `crossplane/crossplane` `main` commit at research time and record the selected design document's status and accuracy warnings.
+
 For each composition function, discover the highest stable semantic-version tag at research time. Exclude prereleases, release candidates, beta tags, alpha tags, draft releases, and moving branches. Resolve the selected tag and the immediately preceding stable tag to full commits when available. Do not silently fall back to `main`.
 
 Issue and pull-request state is mutable. Record a research timestamp and direct GitHub item metadata for project-history evidence instead of presenting it as immutable released source.
@@ -80,6 +82,8 @@ Batch repositories by source kind. Do not spawn one agent per repository. Prefer
 
 Scout official documentation and third-party examples separately from implementation repositories so their authority roles remain explicit in the evidence packet.
 
+Never use `crossplane/crossplane/design/**` for general feature discovery. Locate a design document only for a specific feature already identified from current stable documentation or implementation evidence.
+
 Skip scouting when existing locks and evidence already identify the relevant files and their source paths have not changed.
 
 ### 4. Research only what needs semantics
@@ -88,13 +92,14 @@ Use the narrowest matching researcher:
 
 - `okf-crossplane-core-docs-researcher` for current stable Crossplane Core documentation, terminology, workflows, lifecycle states, and general provider or function installation guidance.
 - `okf-crossplane-core-code-researcher` for current stable Crossplane Core CRDs under `cluster/crds`.
+- `okf-crossplane-core-design-researcher` only as a last-resort historical-context source for a specific Core feature already identified from current stable documentation or implementation evidence.
 - `okf-function-go-templating-researcher` for user-facing `function-go-templating` installation, input schema, README guidance, examples, and additional template functions.
 - `okf-function-go-templating-sprig-researcher` for the exact Sprig version selected by `function-go-templating/go.mod`, restricted by the function map exposed by that release.
 - `okf-function-go-templating-project-history-researcher` for human-authored issues and pull requests, grouped into release changes, known reports, and post-release proposals or developments.
 - `okf-crossplane-researcher` for CLI, runtime, SDKs, tools, native providers, testing tools, examples, and domains without a dedicated researcher.
 - `okf-upjet-researcher` only for Upjet provider concepts that require Terraform correlation. Give it an explicit provider service or managed-resource batch.
 
-Run the Core docs and Core code researchers together when a concept needs both user-facing guidance and exact served API shape.
+Run the Core docs and Core code researchers together when a concept needs both user-facing guidance and exact served API shape. Invoke the Core design researcher afterward only when a bounded historical question remains.
 
 Every composition function must have its own dedicated Codex and Pi agent set. Add that bounded agent set and source profile before generating knowledge for a function that does not have one. A function agent set may include a primary user-facing researcher plus narrowly scoped supporting researchers for dependencies and project history.
 
@@ -110,17 +115,20 @@ Use evidence according to its source role:
 
 - Primary implementation sources, API types, generated schemas, tests, and package metadata establish API shape and runtime behavior.
 - Official Crossplane documentation establishes documented terminology, guidance, supported workflows, lifecycle states, and user-facing examples. When documentation conflicts with implementation or schemas, record the conflict and prefer implementation evidence for runtime behavior.
+- Historical-design sources establish only historical intent, rationale, conceptual models, alternatives, and tradeoffs for a specific already-known feature. They do not independently establish current API shape, runtime behavior, supported guidance, release inclusion, or feature maturity.
 - Supporting sources provide background that is relevant only to their domain, such as Sprig functions, Upjet generation, or Terraform resource behavior.
 - Project-history sources establish that a human-authored issue was reported, a pull request was proposed, or a change was merged. They do not independently establish released behavior, API shape, lifecycle state, or recommendations.
 - Third-party examples are illustrative. They may establish what that repository implements, but they must not be the sole evidence for Crossplane API semantics, runtime behavior, compatibility, security properties, or recommended practices.
 
+For every design-derived statement presented as a current fact, require corroboration from selected stable source code, CRDs, schemas, tests, or matching stable documentation. Otherwise retain it only as historical design intent or unresolved context. Accepted design status does not prove implementation or release inclusion, and design status never defines feature state.
+
 Apply feature-state precedence:
 
-1. Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from selected sources.
+1. Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from selected current sources.
 2. A relevant served `v1alpha*` API is an Alpha stability ceiling and a relevant served `v1beta*` API is a Beta stability ceiling. Never record either as Stable.
 3. When an explicit Stable label conflicts with a served alpha or beta API, classify the API as Alpha or Beta and record the source conflict.
 4. When no explicit label exists, use Alpha for `v1alpha*`, Beta for `v1beta*`, and Stable only when no relevant served alpha or beta API exists.
-5. Never use `v1` alone as proof of Stable; it only permits the repository Stable default when no other selected evidence indicates a non-stable state.
+5. Never use `v1` alone as proof of Stable; it only permits the repository Stable default when no other selected current evidence indicates a non-stable state.
 
 Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or an explicit legacy label.
 
@@ -144,12 +152,13 @@ Before writing Markdown, reduce the evidence packets to a claim ledger:
 
 - concept identifier
 - exact claim
-- claim class: API, behavior, documented guidance, release history, reported limitation, proposal, or illustrative pattern
+- claim class: API, behavior, documented guidance, historical context, release history, reported limitation, proposal, or illustrative pattern
 - source role
 - supporting immutable citation or direct issue/PR snapshot
 - confidence: direct, corroborated, or inferred
 - Crossplane release or documentation series
-- feature state and basis: explicit label, served alpha or beta API ceiling, or Stable repository default when no non-stable evidence exists
+- feature state and basis: explicit label, served alpha or beta API ceiling, or Stable repository default when no non-stable current evidence exists
+- design document status, accuracy warnings, and current corroboration result for historical-design evidence
 - selected-release relationship for issue and pull-request evidence
 - research timestamp for project-history evidence
 - legacy exclusions applied
@@ -165,12 +174,13 @@ Rules:
 
 - one independently useful concept per file
 - structural Markdown over long prose
-- package, schema, behavior, documentation guidance, examples, and project history are separate concepts or sections when each is useful alone
+- package, schema, behavior, documentation guidance, historical context, examples, and project history are separate concepts or sections when each is useful alone
 - preserve existing unknown frontmatter fields
 - add natural-language cross-links, not a generic link dump
 - add a numbered `# Citations` section for externally sourced claims
 - update affected `index.md` files for progressive disclosure
 - update `log.md` only with high-level knowledge changes
+- label design-derived material as historical context and pair current facts with current implementation or documentation evidence
 - identify third-party examples as community examples and name their originating repository
 - distinguish copied examples, adapted examples, and summarized patterns
 - exclude Claims, deprecated CompositeResourceDefinition v1, legacy v1 XR semantics, and sections explicitly labelled `v1 Composite Resources (Legacy)`
@@ -181,7 +191,7 @@ Rules:
 - label open issues as reports and open or unmerged pull requests as proposals
 - include the project-history research timestamp
 
-Do not copy large documentation passages, issue bodies, pull-request descriptions, or comment threads. Summarize and cite.
+Do not copy large design documents, documentation passages, issue bodies, pull-request descriptions, or comment threads. Summarize and cite.
 
 ### 8. Apply the Upjet evidence gate
 
@@ -206,6 +216,8 @@ Also check:
 
 - source lock entries exist for all generated released-source concepts
 - released-source evidence citations contain immutable commit SHAs
+- historical-design citations pin the selected Crossplane commit and record document status and accuracy warnings
+- design documents are not used for general feature discovery, current facts without corroboration, or feature-state classification
 - cited files and line anchors resolve when network access is available
 - internal Markdown links are valid; report broken links as warnings because OKF permits them
 - no concept contains unresolved placeholders presented as facts
@@ -215,7 +227,7 @@ Also check:
 - served `v1alpha*` APIs are never recorded above Alpha and served `v1beta*` APIs are never recorded above Beta
 - an explicit Stable label that conflicts with a served alpha or beta API is recorded as a conflict, not accepted as Stable
 - `v1` alone is not used as proof of Stable
-- Stable is used by repository default only when no selected source or relevant served API indicates a non-stable state
+- Stable is used by repository default only when no selected current source or relevant served API indicates a non-stable state
 - legacy-free output excludes Claims, deprecated XRD v1, legacy v1 XR semantics, and explicitly labelled legacy sections
 - current non-deprecated APIs are not excluded only because they use `/v1`
 - Crossplane CLI content is not categorized as Core
@@ -243,7 +255,7 @@ Shared rules:
 
 - Keep at most three direct research agents active at once.
 - Use one final evidence review over changed concepts, not over all source repositories.
-- Prefer targeted searches, schemas, tests, documentation sections, configured example paths, and issue/PR queries over recursive repository reads.
+- Prefer targeted searches, schemas, tests, documentation sections, explicitly selected design documents, configured example paths, and issue/PR queries over recursive repository reads.
 - Batch related third-party example repositories instead of assigning one agent per repository.
 - Summarize issue and pull-request history by user-facing theme and omit low-signal housekeeping.
 - Return summaries and evidence references, never raw exploration output.
@@ -271,6 +283,7 @@ Report:
 - concepts created, updated, or removed
 - pinned source commits used
 - selected Crossplane release and documentation series for Core work
+- selected historical design documents, pinned commit, stated status, and corroboration result
 - selected stable function tags and commits
 - source roles used for material claims
 - explicit feature-state citations, served alpha or beta API ceilings, or the Stable repository-default basis
@@ -278,5 +291,5 @@ Report:
 - project-history timestamp, human-authored items summarized, and bot/app activity excluded
 - deterministic validation and `mise run lint` results
 - reviewer status
-- unresolved mappings, conflicts, licensing questions, and permitted broken links
+- unresolved mappings, conflicts, licensing questions, historical design differences, and permitted broken links
 - the narrowest next source batch, when more coverage is requested

--- a/.agents/skills/okf/references/evidence-contract.md
+++ b/.agents/skills/okf/references/evidence-contract.md
@@ -7,11 +7,12 @@ Use this compact Markdown structure:
 ```markdown
 ## Scope
 - Repository: owner/name
-- Commit: full SHA when the source is release content
-- Source role: primary | official-documentation | supporting | project-history | third-party-example
-- Requested area: path, package, command, API, documentation section, example, issue/PR theme, or resource batch
+- Commit: full SHA when the source is release content or historical design
+- Source role: primary | official-documentation | historical-design | supporting | project-history | third-party-example
+- Requested area: path, package, command, API, documentation section, design question, example, issue/PR theme, or resource batch
 - Selected release: stable tag, documentation series, or explicitly requested preview revision
 - Research timestamp: required for project-history evidence
+- Design document status: required for historical-design evidence
 - Legacy exclusions applied: exact exclusions relevant to this packet
 
 ## Concept candidates
@@ -24,14 +25,16 @@ Use this compact Markdown structure:
 - Feature-state basis: explicit commit-pinned label; served `v1alpha*` or `v1beta*` API version; or `Stable by repository default because selected sources contain no explicit non-stable label and no relevant served alpha or beta API version`
 - Claims:
   - Claim text
-    - Class: API | behavior | documented-guidance | release-history | reported-limitation | proposal | illustrative-pattern
+    - Class: API | behavior | documented-guidance | historical-context | release-history | reported-limitation | proposal | illustrative-pattern
     - Evidence: commit-pinned URL with line range, or direct issue/PR URL with snapshot metadata
-    - Source role: primary | official-documentation | supporting | project-history | third-party-example
+    - Source role: primary | official-documentation | historical-design | supporting | project-history | third-party-example
     - Confidence: direct | corroborated | inferred
 - Schema sources:
   - path and purpose
 - Examples:
   - path, origin, and what it demonstrates
+- Historical design:
+  - document path, status, revision, stated inaccuracies, and what current evidence corroborates or contradicts
 - Project history:
   - issue or PR number, state, human author, timestamps, selected-release relationship, and concise relevance
 - Relationships:
@@ -63,12 +66,17 @@ Rules:
 - Use `inferred` only for a clearly labelled conclusion that is useful but not explicitly stated.
 - Primary sources establish API shape and runtime behavior.
 - Official documentation establishes documented guidance and user-facing terminology. Record version scope and conflicts with implementation.
+- Historical-design sources establish only historical intent, rationale, conceptual models, alternatives, and tradeoffs for a specific already-known feature.
+- Never use historical-design sources for general feature discovery, current API shape, runtime behavior, supported guidance, release inclusion, or feature maturity.
+- Record the design document status and every prominent warning that it is partially implemented, superseded, semi-defunct, or otherwise inaccurate.
+- Qualify every design-derived current fact with selected stable implementation, schema, test, or matching stable documentation evidence. Without corroboration, report it only as historical design intent or unresolved context.
 - Resolve the latest stable Crossplane release before researching Crossplane Core unless the user explicitly requests another release or preview content.
-- Preserve explicit Alpha, Beta, Preview, Stable, and Deprecated labels from selected sources.
+- Preserve explicit Alpha, Beta, Preview, Stable, and Deprecated labels from selected current sources.
 - A relevant served `v1alpha*` API is an Alpha stability ceiling and a relevant served `v1beta*` API is a Beta stability ceiling. Never record either as Stable.
 - When an explicit Stable label conflicts with a served alpha or beta API version, classify the API as Alpha or Beta and record the source conflict.
 - When no explicit label exists, use Alpha for `v1alpha*`, Beta for `v1beta*`, and Stable only when no relevant served alpha or beta API version exists.
 - Never use `v1` alone as evidence of Stable; it only permits the repository Stable default when no other selected evidence indicates a non-stable state.
+- Never derive feature state from a design document or its Speculative, Draft, Accepted, or Defunct status.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label. Current Crossplane v2 resources may still use a v1 Kubernetes API version.
 - Exclude Claims, deprecated CompositeResourceDefinition v1, and legacy v1 composite-resource semantics from legacy-free catalog work.
 - Project-history evidence must record the research timestamp because issue and pull-request state can change.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -119,6 +119,26 @@ documentation_sources:
       - v1-to-v2 migration guidance unless explicitly requested
     version_scope: current-stable-v2
 
+historical_design_sources:
+  - id: crossplane-core-designs
+    repository: crossplane/crossplane
+    kind: historical-design
+    authority: historical-design
+    agent: okf-crossplane-core-design-researcher
+    revision_policy: pin-current-main-commit-at-research-time
+    paths:
+      - design
+    discovery: disabled
+    invocation: last-resort-for-specific-known-feature
+    requires_current_corroboration: true
+    cannot_define:
+      - current API shape
+      - runtime behavior
+      - supported workflow
+      - release inclusion
+      - feature maturity
+      - general feature inventory
+
 supporting_sources:
   - id: sprig
     repository: Masterminds/sprig
@@ -177,6 +197,10 @@ source_policy:
   prefer_primary_sources: true
   allow_unpinned_citations: false
   allow_name_only_upjet_mapping: false
+  historical_design_can_discover_features: false
+  historical_design_can_define_current_facts: false
+  historical_design_requires_current_corroboration: true
+  historical_design_can_define_feature_state: false
   third_party_examples_can_define_behavior: false
   third_party_examples_require_corroboration: true
   verify_license_before_copying: true

--- a/.codex/agents/okf-crossplane-core-design-researcher.toml
+++ b/.codex/agents/okf-crossplane-core-design-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-crossplane-core-design-researcher"
+description = "Read-only last-resort researcher for historical Crossplane Core design rationale. Use only for a specific feature already identified from current stable documentation or implementation evidence."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-crossplane-core-design-researcher/AGENT.md` as the canonical role instructions."

--- a/.pi/agents/okf-crossplane-core-design-researcher.md
+++ b/.pi/agents/okf-crossplane-core-design-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-crossplane-core-design-researcher
+description: Read-only last-resort researcher for historical Crossplane Core design rationale for a specific known feature.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":10,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-crossplane-core-design-researcher/AGENT.md` as the canonical role instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 
 - Use `okf-crossplane-core-docs-researcher` for current stable Crossplane Core documentation.
 - Use `okf-crossplane-core-code-researcher` for current stable Crossplane Core CRDs under `cluster/crds`.
+- Use `okf-crossplane-core-design-researcher` only as a last-resort historical-context source for a specific Core feature already identified from current stable documentation or implementation evidence. Never use it for general feature discovery.
 - Use `okf-function-go-templating-researcher` for user-facing `function-go-templating` installation, input schema, examples, and additional template functions.
 - Use `okf-function-go-templating-sprig-researcher` for the exact Sprig version exposed by the selected stable `function-go-templating` release.
 - Use `okf-function-go-templating-project-history-researcher` for human-authored issues and pull requests related to that function.
@@ -48,6 +49,10 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Without an explicit feature-state label, treat a served `v1alpha*` API as Alpha and a served `v1beta*` API as Beta. Such APIs must never be recorded as Stable.
 - For APIs without an alpha or beta served version, default the feature state to Stable unless selected sources explicitly label it Alpha, Beta, Preview, or Deprecated.
 - Never use `v1` alone as proof of Stable; it only permits the Stable default when no selected source or served API version indicates a non-stable state.
+- Crossplane Core design documents under `crossplane/crossplane/design/**` are historical design-context sources only. Pin the current `main` commit and record the document status and any accuracy warning.
+- A design document, including an Accepted design, does not establish current implementation, released behavior, supported guidance, or feature maturity.
+- Qualify every design-derived current fact against selected stable source code, CRDs, schemas, tests, or matching stable documentation. Keep uncorroborated material labelled as historical design intent or unresolved context.
+- Never use design documents to discover features or derive Alpha, Beta, Preview, Stable, or Deprecated state.
 - Exclude Claims, claim references, deprecated CompositeResourceDefinition v1, legacy v1 XR semantics, and sections explicitly labelled `v1 Composite Resources (Legacy)` from legacy-free output.
 - Do not treat every `apiextensions.crossplane.io/v1` resource as legacy. Require explicit deprecation metadata or a legacy label.
 - Project-history evidence must exclude bots and apps and record a research timestamp.
@@ -58,9 +63,9 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Verify licensing and attribution before copying or adapting third-party material. Otherwise summarize and cite it.
 - Pin every released source repository to an immutable commit before generating knowledge.
 - Cite source files with commit-pinned GitHub URLs and line ranges whenever practical.
-- Do not convert assumptions, name similarity, issue reports, proposals, or undocumented behavior into facts.
+- Do not convert assumptions, name similarity, issue reports, proposals, design intent, or undocumented behavior into facts.
 - For Upjet resources, do not infer a Terraform mapping from names alone. Require Upjet configuration or generated metadata that identifies the Terraform resource.
-- Preserve disagreements between source code and documentation as explicit notes instead of silently choosing one.
+- Preserve disagreements between source code, documentation, and historical design as explicit notes instead of silently choosing one.
 
 ## Output rules
 


### PR DESCRIPTION
## What changed

- add the canonical `okf-crossplane-core-design-researcher` instructions
- add matching Codex and Pi runtime adapters
- register `crossplane/crossplane/design/**` as a separate `historical-design` source role
- route design research only as a last resort for a specific feature already identified from current stable sources
- prohibit using design documents for general feature discovery
- require every design-derived current fact to be corroborated by current stable source code, CRDs, schemas, tests, or matching official documentation
- record design status and accuracy warnings, including partially implemented or semi-defunct accepted designs
- prevent design status from defining Alpha, Beta, Preview, Stable, or Deprecated state
- extend the evidence contract, shared OKF workflow, source scout, generic researcher exclusions, repository guidance, and reviewer checks

## Why

Crossplane design documents provide useful historical rationale, intended architecture, rejected alternatives, and tradeoffs. They may not match the current implementation, even when marked Accepted. This change keeps that context available without allowing historical design intent to become an unqualified current fact.

## Validation

- branch is based on the latest `main`
- change set is squashed into one commit
- repository comparison shows 10 intended files and no unrelated catalog changes
- runtime adapters reference the canonical agent instructions
- source and evidence policies use the dedicated `historical-design` authority role

`mise run lint` could not be executed in the connector environment because a local repository checkout was unavailable. The PR is opened as draft so repository CI can validate the complete branch before it is marked ready.