### PR TITLE
docs: add function-auto-ready OKF knowledge

### DIFF
--- a/.agents/agents/okf-function-auto-ready-researcher/AGENT.md
+++ b/.agents/agents/okf-function-auto-ready-researcher/AGENT.md
@@ -1,0 +1,50 @@
+# function-auto-ready User Researcher
+
+Extract source-backed, user-facing knowledge for `crossplane-contrib/function-auto-ready` without editing files.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+## Release selection
+
+1. Discover releases and tags at research time.
+2. Select the highest stable semantic-version tag, excluding drafts, prereleases, release candidates, beta tags, alpha tags, and moving branches.
+3. Resolve the selected tag and immediately preceding stable tag to full commit SHAs when available, and record the selected release date.
+4. Cite released source only through immutable commits.
+5. If no stable semantic-version tag exists, report the source as unresolved; never fall back to `main`.
+
+## Default source scope at the selected tag
+
+- `README.md`
+- `package/crossplane.yaml`
+- `fn.go`
+- `fn_test.go`
+- `main.go`
+- `features/**`
+- `cel/**`
+- `healthchecks/**`
+- `input/**`
+- `package/input/autoready.fn.crossplane.io_inputs.yaml`
+- `example/**`
+- `go.mod`
+
+Follow renamed or split files only when they directly establish the same user-visible package, behavior, or example semantics.
+
+## Research focus
+
+- installation and pipeline usage
+- the exact readiness rules applied to desired composed resources
+- annotations, conditions, and observed/desired resource relationships that affect readiness
+- response behavior, events, and limitations visible to composition authors
+- runnable, legacy-free examples and their prerequisites
+- selected release compatibility evidence and feature-state labels
+
+## Evidence boundaries
+
+- Use implementation and tests to establish runtime behavior.
+- Use README and examples to establish documented workflows and user-facing terminology.
+- Do not document internal service architecture, contributor workflows, or unrelated SDK APIs.
+- Exclude Claims, claim references, deprecated CompositeResourceDefinition v1 behavior, and legacy v1 composite-resource semantics.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels. Without one, apply the feature-state rules in the evidence contract.
+- Verify the repository license before proposing copied or adapted material; otherwise summarize and cite.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state. Do not inspect another composition function repository. Do not delegate or write catalog files.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -72,6 +72,26 @@ primary_sources:
   - id: function-auto-ready
     repository: crossplane-contrib/function-auto-ready
     kind: function
+    audience: user
+    release_policy: discover-highest-stable-semver-tag
+    agent_set:
+      primary: okf-function-auto-ready-researcher
+    paths:
+      - README.md
+      - package/crossplane.yaml
+      - fn.go
+      - fn_test.go
+      - main.go
+      - features
+      - cel
+      - healthchecks
+      - input
+      - package/input/autoready.fn.crossplane.io_inputs.yaml
+      - example
+      - go.mod
+    legacy_exclusions:
+      - examples requiring Claims or claim references
+      - examples requiring deprecated v1 XRD or legacy v1 XR semantics
   - id: provider-kubernetes
     repository: crossplane-contrib/provider-kubernetes
     kind: native-provider

--- a/.codex/agents/okf-function-auto-ready-researcher.toml
+++ b/.codex/agents/okf-function-auto-ready-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-auto-ready-researcher"
+description = "Read-only user-facing researcher dedicated to crossplane-contrib/function-auto-ready."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-auto-ready-researcher/AGENT.md` as the canonical role instructions."

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -53,6 +53,31 @@ All claims have function scope v0.12.2 unless a narrower version is stated.
 - README nests `options` under `inline`, conflicting with the generated CRD; catalog follows the generated schema.
 - Bundled installation examples pin v0.11.5 and use varying Function object names; catalog uses selected v0.12.2 and requires name matching.
 
+# function-auto-ready v0.7.0
+
+Selected stable release `v0.7.0` at `ed7886de159af73b9d6976f04f9171ec7a4cb411`; previous stable release `v0.6.6` at `046fe9eca400dfdb835911d8b22da9b0e27a5547`. Claims, claim references, deprecated XRD v1, and legacy v1 XR semantics were excluded. No project-history, historical-design, official-documentation, supporting, or third-party-example evidence was used.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| package | The package declares Composition capability and is used after a pipeline step produces desired resources. | API and documented-guidance | primary | direct | Stable by repository default; [metadata](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/package/crossplane.yaml#L2-L22), [README](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L149-L186) |
+| readiness | Desired resources require a same-key observed resource, and explicit readiness from an earlier function is preserved. | behavior | primary | direct | Stable by repository default; [implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L133-L193) |
+| readiness | Evaluation order is CEL, registered Kubernetes health check, then generic observed `Ready=True` condition. | behavior | primary | direct | Mixed: core Stable by repository default; CEL explicitly Alpha; [implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L193) |
+| readiness | A false built-in check leaves readiness unspecified, allowing the generic condition fallback. | behavior | primary | direct | Stable by repository default; [implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L133-L193) |
+| built-in-health-checks | Fifteen Kubernetes kinds have registered resource-specific checks; exact rules are established by their implementations. | behavior | primary | corroborated | Stable by repository default; [registry](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/registry.go#L58-L74), [README inventory](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L15-L68) |
+| input | Input is a non-installed KRM-like v1beta1 object with TTL and two CEL customization fields. | API | primary | direct | Beta ceiling from served v1beta1 schema; [source](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/input/v1beta1/input.go#L1-L38), [schema](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/package/input/autoready.fn.crossplane.io_inputs.yaml#L18-L60) |
+| input | Input TTL overrides the runtime default; an invalid duration produces a fatal response. | behavior | primary | direct | Beta input; [implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L40-L54) |
+| cel-health-checks | CELHealthcheckCustomizations is explicitly Alpha and disabled by default. | API | primary | direct | Explicit Alpha; [feature registration](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/features/features.go#L7-L18) |
+| cel-health-checks | Rules are keyed by normalized GVK, evaluate observed `object`, return Boolean readiness, and inline entries override context entries. | API and behavior | primary | direct | Explicit Alpha; [resolver](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/cel/resolver.go#L23-L71), [merge](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L100) |
+| cel-health-checks | A CEL evaluation error warns and falls through, conflicting with README language that it is treated as not ready. | behavior and documented-guidance | primary | direct conflict | Explicit Alpha; [runtime](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L119-L159), [README](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L85-L91) |
+
+## function-auto-ready limitations and conflicts
+
+- README CEL snippets use `v1alpha1`, but selected source, generated schema, and runnable example use `v1beta1`; catalog follows the schema-backed v1beta1 API.
+- README links old Crossplane v1.14 documentation; it was not used as current official-documentation evidence.
+- Bundled basic-example package references are timestamp builds, not the selected v0.7.0 release; the catalog summarizes behavior without copying those references.
+- The selected sources do not state a minimum supported Crossplane version.
+- No legacy material was found in the bounded selected-release sources; current `/v1` Composition and Configuration APIs were not excluded merely for using v1.
+
 # Crossplane Core v2.3.3
 
 Selected Core release `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`; matching official documentation series `v2.3` at `f1315464e35d40d25a28e4c15b6725b0e21adf91`.

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -24,6 +24,13 @@ sources:
     previous_tag: v0.12.1
     previous_commit: 548ae34fd9c843f0747981894fb7fa0ff1ba47fa
     resolved_at: 2026-07-14
+  function-auto-ready:
+    repository: crossplane-contrib/function-auto-ready
+    tag: v0.7.0
+    commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+    previous_tag: v0.6.6
+    previous_commit: 046fe9eca400dfdb835911d8b22da9b0e27a5547
+    resolved_at: 2026-07-14
   sprig:
     repository: Masterminds/sprig
     tag: v3.3.0

--- a/.pi/agents/okf-function-auto-ready-researcher.md
+++ b/.pi/agents/okf-function-auto-ready-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-auto-ready-researcher
+description: Read-only user-facing researcher dedicated to crossplane-contrib/function-auto-ready.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-auto-ready-researcher/AGENT.md` as the canonical role instructions.

--- a/catalog/functions/function-auto-ready/built-in-health-checks.md
+++ b/catalog/functions/function-auto-ready/built-in-health-checks.md
@@ -1,0 +1,49 @@
+---
+type: reference
+title: function-auto-ready built-in health checks
+description: Kubernetes resource-specific readiness checks registered by function-auto-ready v0.7.0.
+resource: https://github.com/crossplane-contrib/function-auto-ready
+tags: [crossplane, function, kubernetes, readiness]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths: [README.md, healthchecks]
+release: v0.7.0
+feature_state: Stable
+feature_state_basis: Stable by repository default because selected sources contain no explicit non-stable label and no relevant served alpha or beta API.
+---
+
+# Behavior
+
+The selected release registers specialized checks for 15 Kubernetes resource kinds.[1]
+
+| Resource | Ready when |
+|---|---|
+| ConfigMap, Namespace, Secret, ServiceAccount | The resource exists in observed state. |
+| Pod | Phase is `Succeeded`, or phase is `Running`, restart policy is `Always`, and condition `Ready=True`. |
+| Service | It is not type `LoadBalancer`, or it has at least one load-balancer ingress entry. |
+| PersistentVolumeClaim | Phase is `Bound`. |
+| Deployment | Desired replicas equal updated and available replicas, with condition `Available=True`. |
+| StatefulSet | Desired replicas equal ready and current replicas, and current revision equals update revision. |
+| DaemonSet | Desired scheduled pods equal ready, updated, and available counts. |
+| ReplicaSet | Observed generation is current, no true replica-failure condition exists, and available replicas meet desired replicas. |
+| Job | Condition `Complete=True`, unless a true failed or suspended condition is encountered first. |
+| CronJob | It is suspended, has an active job, or its last successful time is at or after its last schedule time. |
+| HorizontalPodAutoscaler | A true `ScalingActive` or `ScalingLimited` condition is encountered without an earlier recognized failure-like condition. |
+| Ingress | It has at least one load-balancer ingress entry. |
+
+The README provides the inventory, while the resource-specific implementations establish exact rules.[2][3][4][5][6]
+
+# Limitations
+
+Resources without a registered check use the generic `Ready=True` condition fallback. A specialized check returning false also leaves readiness unspecified and does not prevent that fallback.[7]
+
+# Citations
+
+[1] [Registered health checks](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/registry.go#L58-L74)
+[2] [README health-check inventory](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L15-L68)
+[3] [Pod implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/pod.go#L18-L66)
+[4] [Deployment implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/deployment.go#L17-L73)
+[5] [Job implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/job.go#L18-L45)
+[6] [HPA implementation](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/healthchecks/horizontalpodautoscaler.go#L18-L50)
+[7] [Built-in and fallback ordering](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L133-L193)

--- a/catalog/functions/function-auto-ready/cel-health-checks.md
+++ b/catalog/functions/function-auto-ready/cel-health-checks.md
@@ -1,0 +1,45 @@
+---
+type: function
+title: function-auto-ready CEL health checks
+description: Alpha, feature-gated readiness expressions evaluated against observed composed resources.
+resource: https://github.com/crossplane-contrib/function-auto-ready
+tags: [crossplane, function, cel, readiness, alpha]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths: [README.md, features/features.go, cel/resolver.go, fn.go]
+release: v0.7.0
+feature_state: Alpha
+feature_state_basis: CELHealthcheckCustomizations is explicitly registered as Alpha and disabled by default.
+---
+
+# Overview
+
+Enable the `CELHealthcheckCustomizations` Alpha feature gate to define per-GVK readiness expressions. It is disabled by default.[1]
+
+Rule keys use `<group>_<version>_<kind>`, replacing dots in the group with underscores. Each expression receives the observed
+resource as `object` and must return a Boolean. `true` sets explicit `Ready=True`; `false` sets explicit `Ready=False`.[2]
+
+# Sources and precedence
+
+Rules may come from the request context field path named by `celHealthCheckCustomizationFrom`, the inline `celHealthCheckCustomization` map, or both. Context rules load first; inline entries overwrite matching keys.[3]
+
+The bundled example reads rules from an EnvironmentConfig-populated context and checks that a Crossplane Configuration reports both `Installed=True` and `Healthy=True`. This catalog summarizes the example; it does not copy it.[4]
+
+# Limitations
+
+The README says an evaluation error is treated as not ready and that a customization takes precedence over a built-in check.
+The implementation instead emits a Warning and leaves readiness unspecified after an error, allowing later built-in or generic
+fallback stages to mark the resource ready. Runtime behavior here follows the implementation.[5][6]
+
+The README's CEL snippets use `v1alpha1`, conflicting with the selected [v1beta1 Input](input.md). Use the schema-backed `v1beta1` API.[7]
+
+# Citations
+
+[1] [Alpha feature gate](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/features/features.go#L7-L18)
+[2] [CEL key, type, and readiness mapping](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/cel/resolver.go#L23-L71)
+[3] [Context and inline merge order](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L100)
+[4] [Bundled CEL example](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck/README.md#L14-L64)
+[5] [README error and precedence description](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L85-L91)
+[6] [Runtime error fallthrough](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L119-L159)
+[7] [README v1alpha1 snippets](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L100-L129)

--- a/catalog/functions/function-auto-ready/index.md
+++ b/catalog/functions/function-auto-ready/index.md
@@ -1,0 +1,17 @@
+---
+type: index
+title: function-auto-ready index
+description: Progressive index for function-auto-ready v0.7.0.
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Package and behavior
+
+* [Function package](package.md) - Install and place function-auto-ready in a Composition pipeline.
+* [Readiness behavior](readiness.md) - Understand readiness ordering, observed-resource matching, and fallback behavior.
+* [Built-in health checks](built-in-health-checks.md) - See Kubernetes resource kinds with specialized readiness rules.
+
+# Input and optional features
+
+* [Input](input.md) - Configure response caching and the Alpha CEL customization inputs.
+* [CEL health checks](cel-health-checks.md) - Override readiness checks with Alpha, feature-gated CEL expressions.

--- a/catalog/functions/function-auto-ready/input.md
+++ b/catalog/functions/function-auto-ready/input.md
@@ -1,0 +1,41 @@
+---
+type: functioninput
+title: function-auto-ready Input v1beta1
+description: Input fields for response caching and CEL readiness customizations in function-auto-ready v0.7.0.
+resource: https://github.com/crossplane-contrib/function-auto-ready
+tags: [crossplane, function, input, readiness]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths: [input/v1beta1/input.go, package/input/autoready.fn.crossplane.io_inputs.yaml]
+release: v0.7.0
+feature_state: Beta
+feature_state_basis: The selected generated schema serves and stores v1beta1, which sets a Beta ceiling.
+---
+
+# Schema
+
+Use `apiVersion: autoready.fn.crossplane.io/v1beta1` and `kind: Input`. This KRM-like input is not installed as a Kubernetes CRD; the repository generates a CRD-shaped schema to describe it.[1]
+
+| Field | Type | Behavior |
+|---|---|---|
+| `ttl` | string | Go duration for response caching; generated default is `1m0s`. |
+| `celHealthCheckCustomization` | map of strings | Inline GVK-to-CEL rules for the Alpha CEL feature. |
+| `celHealthCheckCustomizationFrom` | string | Field path to a CEL-rule map in Function request context. |
+
+The `ttl` value overrides the runtime default. An invalid duration produces a fatal Function response.[2][3]
+
+# Limitations
+
+The selected README's inline CEL examples specify `v1alpha1`, but the selected source and generated schema define only `v1beta1`. Use `v1beta1`; the runnable CEL example also uses it.[4][5]
+
+The CEL fields belong to an explicitly Alpha, default-disabled feature even though the enclosing input API is Beta. See [CEL health checks](cel-health-checks.md).[6]
+
+# Citations
+
+[1] [Input source and non-CRD note](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/input/v1beta1/input.go#L1-L38)
+[2] [Generated v1beta1 schema](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/package/input/autoready.fn.crossplane.io_inputs.yaml#L18-L60)
+[3] [Runtime TTL parsing](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L40-L54)
+[4] [README v1alpha1 examples](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L100-L129)
+[5] [Runnable v1beta1 example](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck/composition.yaml#L42-L48)
+[6] [Alpha feature registration](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/features/features.go#L7-L18)

--- a/catalog/functions/function-auto-ready/package.md
+++ b/catalog/functions/function-auto-ready/package.md
@@ -1,0 +1,39 @@
+---
+type: function
+title: function-auto-ready
+description: A Composition Function that determines desired composed-resource readiness from observed resources.
+resource: https://github.com/crossplane-contrib/function-auto-ready
+tags: [crossplane, function, composition, readiness]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths: [README.md, package/crossplane.yaml]
+release: v0.7.0
+feature_state: Stable
+feature_state_basis: Stable by repository default because selected sources contain no explicit non-stable label and the core function has no relevant served alpha or beta API.
+---
+
+# Overview
+
+`function-auto-ready` is a Composition Function. It runs after earlier pipeline steps have added desired composed resources,
+compares them with observed resources, and reports the readiness it can determine. The selected catalog release is `v0.7.0`.[1][2]
+
+The package declares only the `composition` capability. Its metadata identifies the source repository and Apache-2.0 license.[2]
+
+# Pipeline placement
+
+Reference the installed Function by its Kubernetes object name in a later pipeline step. No function input is required for default readiness detection.[1]
+
+The function consumes desired resources created by preceding steps; see [readiness behavior](readiness.md). Optional response caching and CEL fields are documented in [Input](input.md).
+
+# Version scope
+
+This concept describes stable tag `v0.7.0`, pinned to commit `ed7886de159af73b9d6976f04f9171ec7a4cb411`. The immediately preceding stable release is `v0.6.6`, pinned to `046fe9eca400dfdb835911d8b22da9b0e27a5547`.
+
+The repository does not state a minimum supported Crossplane version. Its Go dependency on Crossplane API modules is build-time evidence, not a user-facing compatibility guarantee.[3]
+
+# Citations
+
+[1] [README pipeline example](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L149-L186)
+[2] [Function package metadata](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/package/crossplane.yaml#L2-L22)
+[3] [Selected release dependencies](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/go.mod#L5-L16)

--- a/catalog/functions/function-auto-ready/readiness.md
+++ b/catalog/functions/function-auto-ready/readiness.md
@@ -1,0 +1,40 @@
+---
+type: function
+title: function-auto-ready readiness behavior
+description: The ordered rules function-auto-ready v0.7.0 uses to determine composed-resource readiness.
+resource: https://github.com/crossplane-contrib/function-auto-ready
+tags: [crossplane, function, readiness]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths: [fn.go, fn_test.go]
+release: v0.7.0
+feature_state: Stable
+feature_state_basis: Stable by repository default because selected sources contain no explicit non-stable label and no relevant served alpha or beta API.
+---
+
+# Behavior
+
+The function evaluates only desired composed resources that have an observed resource under the same request resource-name key. It preserves `Ready=True` or `Ready=False` set by an earlier pipeline function.[1]
+
+For resources whose readiness remains unspecified, evaluation proceeds in this order:
+
+1. When the Alpha CEL feature is enabled and a rule matches the observed resource GVK, a successful Boolean result sets explicit readiness.[2]
+2. A registered [built-in Kubernetes health check](built-in-health-checks.md) sets `Ready=True` when it succeeds.[3]
+3. A remaining resource becomes ready when its observed object has a `Ready` condition with status `True`.[4]
+
+A failed built-in check does not set `Ready=False`; it leaves readiness unspecified, so the generic condition fallback still runs. An unobserved desired resource also remains unspecified.[3][4]
+
+The implementation matches resources by the desired and observed maps supplied in the Function request. It does not inspect composition-resource-name annotations itself.[1]
+
+# Limitations
+
+The function writes desired composed-resource readiness. The README's statement that Crossplane considers an XR ready after all desired resources are ready describes downstream Crossplane behavior, not behavior implemented here.[5]
+
+# Citations
+
+[1] [Desired and observed resource matching](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L102-L119)
+[2] [CEL evaluation stage](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L130)
+[3] [Built-in health-check stage](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L133-L159)
+[4] [Generic Ready-condition fallback](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L161-L193)
+[5] [README readiness overview](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L4-L13)

--- a/catalog/functions/index.md
+++ b/catalog/functions/index.md
@@ -16,6 +16,7 @@ timestamp: 2026-07-12T00:00:00Z
 * [Composition Functions specification](composition-function-specification.md) - Normative contract for serving, desired state, packaging, and runtime assumptions.
 
 * [function-go-templating](function-go-templating/) - Render desired resources from Go templates in a composition pipeline.
+* [function-auto-ready](function-auto-ready/) - Determine desired composed-resource readiness from observed resources.
 
 # Operation Functions
 

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -8,6 +8,7 @@ timestamp: 2026-07-12T00:00:00Z
 # Catalog Update Log
 
 ## 2026-07-14
+* **Creation**: Added a release-pinned function-auto-ready v0.7.0 knowledge set covering package use, readiness ordering, Kubernetes health checks, Beta input, and Alpha CEL customizations.
 * **Creation**: Added the Crossplane v2 function-go-templating pattern for aggregating observed connection details into an explicitly composed Kubernetes Secret.
 * **Update**: Documented function-go-templating Context semantics and the Crossplane v2 compatibility boundary of all special meta kinds.
 * **Update**: Documented exact function-go-templating helper semantics and added a dedicated ExtraResources capability reference.


### PR DESCRIPTION
## Summary
- add a dedicated read-only researcher profile and Codex/Pi adapters for function-auto-ready
- pin stable function-auto-ready v0.7.0 and its previous stable release
- document package use, readiness ordering, built-in Kubernetes checks, v1beta1 input, and Alpha CEL customizations
- preserve README/source conflicts for CEL API version and evaluation-error behavior

## Validation
- okf-reviewer: APPROVED
- mise run lint: 44 concepts, 0 errors, 0 warnings, 0 infos