### PR TITLE
docs: add provider-backed external query pattern

### DIFF
--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -98,6 +98,10 @@ primary_sources:
   - id: provider-helm
     repository: crossplane-contrib/provider-helm
     kind: native-provider
+  - id: provider-opentofu
+    repository: upbound/provider-opentofu
+    kind: native-provider
+    release_policy: discover-highest-stable-semver-tag
   - id: function-patch-and-transform
     repository: crossplane-contrib/function-patch-and-transform
     kind: function

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -142,6 +142,26 @@ Selected Crossplane `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`, docs
 
 # Crossplane Functions taxonomy and specification
 
+## Provider-backed external query pattern
+
+Selected Core release `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`; matching documentation `v2.3` at `f1315464e35d40d25a28e4c15b6725b0e21adf91`; function-go-templating `v0.12.2` at `0a1e6d386f4363fae257ddbfb5b497416370e830`; provider-opentofu `v1.1.4` at `6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609`. Project history was researched on 2026-07-14. Claims, deprecated XRD v1, legacy v1 XR semantics, and bot/app activity were excluded.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| provider-backed-external-query | Issue #4141 reports that observe-only MRs require unique identity and do not provide general property queries; proposed alternatives are not released query semantics. | reported-limitation and proposal | project-history | direct as report | Open human-authored [issue #4141](https://github.com/crossplane/crossplane/issues/4141), researched 2026-07-14 |
+| provider-backed-external-query | Composition step credentials use literal Secret names and namespaces; issue #7343 reports the resulting dynamic per-XR credential-selection gap. | API, behavior, and reported-limitation | primary and project-history | corroborated | Stable by repository default; [API](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/apis/apiextensions/v1/composition_common.go#L75-L125), [controller](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/internal/controller/apiextensions/composite/composition_functions.go#L357-L375), open [issue #7343](https://github.com/crossplane/crossplane/issues/7343) |
+| provider-backed-external-query | A namespaced provider-opentofu Workspace accepts inline module text, selects ProviderConfig, and publishes non-sensitive outputs at `status.atProvider.outputs`. | API and documented-guidance | primary | corroborated | Beta from served v1beta1; [types](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/apis/namespaced/v1beta1/workspace_types.go#L84-L187), [README](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/README.md#L22-L45) |
+| provider-backed-external-query | A namespaced Workspace resolves a namespaced ProviderConfig and its credential Secret references in the Workspace namespace. | behavior | primary | direct | Beta from served v1beta1; [resolution](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/internal/clients/client.go#L67-L107), [Secret namespace](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/internal/clients/client.go#L138-L147) |
+| provider-backed-external-query | function-go-templating can name the Workspace as a composed resource and retrieve it from observed state on a later reconciliation; absent paths require a guard. | behavior and illustrative-pattern | primary and user-supplied example | corroborated | Beta from [GoTemplate v1beta1 CRD](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/package/input/gotemplating.fn.crossplane.io_gotemplates.yaml#L8-L22); [resource name](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/function_maps.go#L101-L103), [observed lookup](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/function_maps.go#L124-L132) |
+
+### Limitations and unresolved points
+
+- The user-supplied AWS SSO data-source pattern is illustrative and was not independently executed against the pinned releases.
+- The user reports one namespace per tenant and a namespaced ProviderConfig containing only tenant-level credentials. Released code corroborates same-namespace configuration and Secret lookup; tenant authorization still depends on Workspace placement, RBAC, and preventing unintended ClusterProviderConfig or cross-tenant object control.
+- The downstream schema determines whether omitting `principalArn` before the output exists is valid.
+- Neither open issue has a linked released resolution in Crossplane v2.3.3.
+- provider-opentofu is Apache-2.0 licensed. Its upstream example is summarized and cited; the rendered Workspace snippet is adapted from user-supplied material with no identified external provenance.
+
 Selected Core release `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`; matching documentation `v2.3` at `f1315464e35d40d25a28e4c15b6725b0e21adf91`. The Composition Functions specification is sourced directly from the selected v2.3.3 release. Claims, deprecated XRD v1, legacy v1 XR semantics, and CLI material were excluded.
 
 | Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -51,6 +51,11 @@ sources:
     previous_tag: v0.6.6
     previous_commit: 046fe9eca400dfdb835911d8b22da9b0e27a5547
     resolved_at: 2026-07-14
+  provider-opentofu:
+    repository: upbound/provider-opentofu
+    tag: v1.1.4
+    commit: 6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609
+    resolved_at: 2026-07-14
   sprig:
     repository: Masterminds/sprig
     tag: v3.3.0

--- a/catalog/functions/function-go-templating/index.md
+++ b/catalog/functions/function-go-templating/index.md
@@ -12,6 +12,7 @@ timestamp: 2026-07-14T00:00:00Z
 * [Request data and context](request-data.md) - Read request state, extra resources, context, and credentials.
 * [Context](context.md) - Read, create, and deeply update shared function-pipeline context.
 * [ExtraResources](extra-resources.md) - Request cluster resources by name or labels and consume them directly or through pipeline context.
+* [Provider-backed external queries](provider-backed-external-query.md) - Query external APIs through a provider-opentofu Workspace and consume observed outputs safely.
 * [Connection details](connection-details.md) - Aggregate observed connection details into an explicitly composed Kubernetes Secret for v2 composite resources.
 * [Rendered output](rendered-output.md) - Name resources, report readiness, update status, and handle v2 connection details.
 * [Template functions](template-functions.md) - Use project-specific helpers and understand the Sprig boundary.

--- a/catalog/functions/function-go-templating/provider-backed-external-query.md
+++ b/catalog/functions/function-go-templating/provider-backed-external-query.md
@@ -1,0 +1,178 @@
+---
+type: example
+title: Provider-backed external queries in function-go-templating
+description: Query external APIs through a provider-opentofu Workspace and consume its observed outputs in a later Go-template reconciliation.
+resource: https://github.com/crossplane/crossplane/issues/4141
+tags: [crossplane, composition-function, function-go-templating, provider-opentofu, multitenancy]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: upbound/provider-opentofu
+source_tag: v1.1.4
+source_commit: 6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609
+research_timestamp: 2026-07-14
+feature_state: Beta
+feature_state_basis: The namespaced provider-opentofu Workspace and function-go-templating input APIs used by the pattern are served as v1beta1.
+---
+
+# Problem
+
+Crossplane issue #4141 reports that an observe-only managed resource still
+models one external object identified by a unique external identifier; it does
+not provide a general query by tags or properties. Zero, multiple, or changing
+matches do not naturally fit that one-to-one relationship. The open issue
+discusses query functions, provider data sources, required resources, and a
+provider-integrated query API as alternatives, but does not establish that a
+general query facility shipped in Crossplane v2.3.3.[1]
+
+# Multi-tenant credential boundary
+
+Crossplane v2.3.3 supports credentials on a Composition pipeline step, but each
+Secret name and namespace is a literal value in the Composition. The controller
+reads that exact Secret and passes its data to the function. It does not resolve
+the reference from XR fields or pipeline context.[2][3]
+
+Issue #7343 therefore reports a narrower gap than “Functions have no
+credentials”: a function using one statically referenced Secret or one pod
+identity cannot by that mechanism select different credentials for each XR or
+tenant. The open issue proposes dynamic credential references and describes a
+two-pass required-resource workaround. It does not prove that every custom
+query function—or `upbound/function-azresourcegraph` in every configuration—
+fails in a multi-tenant deployment.[4]
+
+A provider-backed query can be useful when tenant credential selection already
+uses ProviderConfig. Unlike the static Function credential reference described
+above, each Workspace selects a ProviderConfig. In the user-reported design,
+each tenant has its own namespace, the Workspace references a namespaced
+ProviderConfig in that namespace, and only tenant-level credentials are exposed
+through that configuration. This keeps cloud authentication and external
+querying in a managed resource while function-go-templating only renders and
+observes the Kubernetes object. The selected provider implementation resolves
+a namespaced ProviderConfig in the Workspace namespace and forces that
+configuration's credential Secret references into the same namespace.[5][12][13]
+With the namespace and RBAC assumptions below, this avoids the static
+per-Composition Function Secret reference for this query path.
+
+# Pattern
+
+provider-opentofu v1.1.4 serves the namespaced
+`opentofu.m.upbound.io/v1beta1` `Workspace`. An inline Workspace accepts OpenTofu
+module text and a typed `providerConfigRef`. Non-sensitive outputs are published
+in the arbitrary JSON map `status.atProvider.outputs`; sensitive outputs belong
+in the connection Secret instead. The Go-template pipeline input used here is
+also served as `gotemplating.fn.crossplane.io/v1beta1`.[5][6][14]
+
+The provider's upstream observe-only example uses an AWS data source, patches a
+Workspace output to XR status, then patches that status into another managed
+resource. The following is an adapted, user-reported variant that keeps the
+rendering in function-go-templating and queries an AWS IAM Identity Center
+administrator role. It has not been independently executed against the pinned
+releases. The snippet was supplied by the user and is not copied from the
+upstream example.[7]
+
+```gotemplate
+{{- $name := .observed.composite.resource.metadata.name }}
+{{- $iamAdminRole := printf "role-iam-administrator-%s" $name }}
+---
+apiVersion: opentofu.m.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  annotations:
+    {{ setResourceNameAnnotation $iamAdminRole }}
+  name: {{ $iamAdminRole }}
+spec:
+  forProvider:
+    source: Inline
+    module: |-
+      output "principal_arn" {
+        value = one(data.aws_iam_roles.account_administrator_role.arns)
+      }
+
+      data "aws_iam_roles" "account_administrator_role" {
+        name_regex  = "AWSReservedSSO_AccountAdministratorAccess_.*"
+        path_prefix = "/aws-reserved/sso.amazonaws.com/"
+
+        lifecycle {
+          postcondition {
+            condition = length(self.arns) == 1
+            error_message = length(self.arns) == 0 ? "Could not find the AWS SSO administrator role ARN" : (
+              "Found more than one AWS SSO administrator role ARN"
+            )
+          }
+        }
+      }
+  providerConfigRef:
+    kind: ProviderConfig
+    name: opentofu
+```
+
+`setResourceNameAnnotation` makes the Workspace a named desired composed
+resource. On a later reconciliation, retrieve the observed Workspace by the
+same composition resource name and guard the normally absent first-observation
+path before rendering a dependent field:[8][9]
+
+```gotemplate
+{{- $dataIAMAdminRole := getComposedResource . $iamAdminRole }}
+{{- $principalArn := dig "status" "atProvider" "outputs" "principal_arn" "" ($dataIAMAdminRole | default (dict)) }}
+{{- if $principalArn }}
+principalArn: {{ $principalArn | quote }}
+{{- end }}
+```
+
+Whether `principalArn` may be omitted until the output exists depends on the
+downstream resource schema. The unguarded expression
+`get $dataIAMAdminRole.status.atProvider.outputs "principal_arn"` can fail
+before `get` runs when the Workspace or an intermediate status map is absent.
+
+# Limitations
+
+- The repeated `ProviderConfig` name `opentofu` refers to a distinct namespaced
+  object in each tenant namespace. The isolation conclusion assumes that the
+  Workspace is also created in that namespace and that Kubernetes RBAC and
+  Secret access prevent cross-tenant configuration or credential use.
+- The provider performs namespace-based lookup; it does not independently
+  establish tenant authorization. Prevent unintended `ClusterProviderConfig`
+  use and restrict who may create or change Workspaces, ProviderConfigs, and
+  credential Secrets.
+- ProviderConfig determines how the Workspace authenticates; this example does
+  not prescribe a Secret layout or cloud authentication backend.
+- Only non-sensitive outputs should be consumed from
+  `status.atProvider.outputs`.[6]
+- provider-opentofu warns that local state is not persisted, long-running
+  modules can exceed the default timeout, and Workspace reconciliation can be
+  CPU-intensive.[10]
+
+# Licensing and attribution
+
+provider-opentofu is Apache-2.0 licensed.[11] The upstream observe-only example
+is summarized and cited rather than copied. The Go-template and OpenTofu module
+above adapt material supplied directly by the user for this catalog change; no
+external provenance for that material was identified.
+
+# Project-history boundaries
+
+Issues #4141 and #7343 were open and human-authored at the 2026-07-14 research
+timestamp. No linked released change was found that resolves either report in
+Crossplane v2.3.3. Bot and app activity was excluded; one GitHub Actions stale
+comment on #4141 was omitted.
+
+# Relationships
+
+See [request data and context](request-data.md) for observed resources and
+credentials, and [rendered output](rendered-output.md) for composition resource
+names and readiness.
+
+# Citations
+
+[1] [Crossplane issue #4141](https://github.com/crossplane/crossplane/issues/4141)
+[2] [Composition credential API](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/apis/apiextensions/v1/composition_common.go#L75-L125)
+[3] [Released Secret loading behavior](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/internal/controller/apiextensions/composite/composition_functions.go#L357-L375)
+[4] [Crossplane issue #7343](https://github.com/crossplane/crossplane/issues/7343)
+[5] [Workspace input and output types](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/apis/namespaced/v1beta1/workspace_types.go#L84-L187)
+[6] [Workspace output publication](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/README.md#L22-L45)
+[7] [Upstream observe-only data-source pattern](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/examples/cluster/observe-only-composition/composition.yaml#L12-L57)
+[8] [Resource-name annotation helper](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/function_maps.go#L101-L103)
+[9] [Observed composed-resource helper](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/function_maps.go#L124-L132)
+[10] [provider-opentofu limitations](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/README.md#L120-L133)
+[11] [provider-opentofu Apache-2.0 license](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/LICENSE)
+[12] [Namespaced ProviderConfig resolution](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/internal/clients/client.go#L67-L107)
+[13] [Credential Secret namespace enforcement](https://github.com/upbound/provider-opentofu/blob/6a1a4f3a3c174b4f6d91c84e74c4a5b6781b0609/internal/clients/client.go#L138-L147)
+[14] [GoTemplate v1beta1 generated CRD](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/package/input/gotemplating.fn.crossplane.io_gotemplates.yaml#L8-L22)

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -8,6 +8,7 @@ timestamp: 2026-07-12T00:00:00Z
 # Catalog Update Log
 
 ## 2026-07-14
+* **Creation**: Added a provider-opentofu and function-go-templating pattern for external queries, including static Function credential limits in multi-tenant pipelines.
 * **Update**: Added the Management Policies GA tracker, grouped known limitation reports, and selected-release containment for implemented policy combinations.
 * **Update**: Expanded function-go-templating issue #579 with its version scope, reported failure mode, proposed workarounds, and unresolved current-release applicability.
 * **Creation**: Documented the absence of native Composition health status and the evidence boundaries of Argo CD Lua and Flux CEL health customizations.


### PR DESCRIPTION
Documents Crossplane issue 4141 and the dynamic Function credential limitation reported in issue 7343. Adds a provider-opentofu and function-go-templating pattern for tenant-namespaced external queries, including guarded output consumption, evidence boundaries, licensing, and RBAC assumptions.\n\nValidation: mise run lint\nReviewer: APPROVED