### PR TITLE
docs: document composed resource RBAC

### DIFF
--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -287,3 +287,22 @@ Selected Core release `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`; ma
 - The six issues are not flattened into a single root cause; only runtime #902 has a released fix proven in the selected source.
 - Two GitHub Actions comments on #6898, two on #6824, and one on #6453 were excluded. Stale automation did not establish resolution.
 - No source material was copied or adapted. Crossplane implementation is Apache-2.0 and Crossplane documentation is CC BY 4.0.
+
+# Composed-resource RBAC
+
+Selected Core release `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`; matching documentation `v2.3` at `f1315464e35d40d25a28e4c15b6725b0e21adf91`. The workflow is Stable by repository default because selected current documentation contains no explicit non-stable label and no relevant served alpha or beta API. Claims, deprecated XRD v1, legacy v1 XR semantics, and CLI material were excluded.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| composed-resource-rbac | Crossplane uses its service account to create function-produced composed resources, but it does not have unrestricted access to every Kubernetes resource kind by default. | documented-guidance | official-documentation | direct | Stable by repository default; [controller identity](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L277-L280), [default scope](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L282-L288) |
+| composed-resource-rbac | Default access covers resources installed by Providers (managed resources), resources defined by XRDs (composite resources), and some Kubernetes kinds required by Crossplane, such as Deployments. | documented-guidance | official-documentation | direct | Stable by repository default; [default scope](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L282-L288) |
+| composed-resource-rbac | Operators grant another kind by creating a ClusterRole with the required rules and the `rbac.crossplane.io/aggregate-to-crossplane: "true"` label. | documented-guidance | official-documentation | direct | Stable by repository default; [grant procedure](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L290-L321) |
+| composed-resource-rbac | The documented CloudNativePG example grants all verbs on `postgresql.cnpg.io` `clusters`; the docs do not claim this is a least-privilege rule. | documented-guidance | official-documentation | direct | Stable by repository default; [example](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L299-L316) |
+| composed-resource-rbac | The RBAC manager is installed and enabled by default, automatically grants Crossplane access to managed and composite resources, and separately manages Provider service-account roles. | behavior and documented-guidance | official-documentation | direct | Stable by repository default; [default deployment](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/guides/pods.md#L206-L227), [responsibilities](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/guides/pods.md#L246-L260) |
+| composed-resource-rbac | With the RBAC manager disabled, operators must manually grant access to every composed kind, including managed and composite resources. | documented-guidance | official-documentation | direct | Stable by repository default; [disabled-manager consequence](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L324-L333) |
+
+## Composed-resource RBAC limitations and exclusions
+
+- The selected documentation does not enumerate the complete default Kubernetes-kind allowlist or least-privilege verbs for arbitrary composed kinds.
+- Current v2.3 guidance uses an aggregated ClusterRole, not ControllerConfig, for the access grant.
+- No source manifest was copied or adapted. Crossplane documentation is CC BY 4.0.

--- a/catalog/core/composed-resource-rbac.md
+++ b/catalog/core/composed-resource-rbac.md
@@ -1,0 +1,88 @@
+---
+type: concept
+title: Grant Crossplane access to composed Kubernetes resources
+description: Crossplane is not authorized for every Kubernetes resource kind by default; operators grant additional composed-resource access with an aggregated ClusterRole.
+resource: https://docs.crossplane.io/v2.3/composition/compositions/#grant-access-to-composed-resources
+tags: [crossplane, core, composition, rbac, security]
+timestamp: 2026-07-14T00:00:00Z
+crossplane_release: v2.3.3
+documentation_series: v2.3
+source_repository: crossplane/docs
+source_commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
+source_paths:
+  - content/v2.3/composition/compositions.md
+  - content/v2.3/guides/pods.md
+feature_state: Stable by repository default
+---
+
+# Overview
+
+Crossplane uses its service account to create and manage the composed resources
+returned by a Composition function pipeline.[1] That service account does not
+have unrestricted access to every Kubernetes resource kind by default.
+
+The default permission scope covers resources installed by Providers
+(managed resources), resources defined by XRDs (composite resources), and
+some Kubernetes kinds Crossplane needs for its own operation, such as
+`Deployment`.[2] The documentation does not provide an exhaustive list of
+those built-in kinds.
+
+# Grant additional access
+
+Before a Composition can manage another resource kind, create a Kubernetes
+`ClusterRole` containing the required API groups, resources, and verbs. Add
+this label so Kubernetes aggregates the new permissions into Crossplane's
+primary `ClusterRole`:[3]
+
+```yaml
+metadata:
+  labels:
+    rbac.crossplane.io/aggregate-to-crossplane: "true"
+```
+
+The official example grants all verbs on the plural resource `clusters` in
+the `postgresql.cnpg.io` API group so Crossplane can compose CloudNativePG
+clusters.[4] Treat that manifest as an example, not as a minimum-permissions
+template: the selected documentation does not enumerate the least-privilege
+verbs needed for every reconciliation case.
+
+# RBAC manager
+
+Crossplane installs and enables its RBAC manager by default.[5] It
+automatically grants the Crossplane service account access to managed and
+composite resources and separately creates and binds roles for Provider
+service accounts.[6]
+
+If the RBAC manager is disabled, operators must manually grant the Crossplane
+service account access to every kind it should compose, including managed and
+composite resources.[7] The Helm value `rbacManager.deploy: false` disables it
+at installation time; after installation, the documented procedure is to
+delete the `crossplane-rbac-manager` Deployment.[5]
+
+# Relationships
+
+A [Composition](composition.md) defines the desired composed resources. This
+concept describes the controller-side authorization Crossplane needs to apply
+them. Crossplane controller permissions and Provider controller permissions
+are distinct, even though the default RBAC manager helps configure both.[6]
+
+# Limitations
+
+Current v2.3 guidance uses an aggregated Kubernetes `ClusterRole`, not a
+`ControllerConfig`, for this grant. The documentation establishes the
+supported operator workflow but does not enumerate Crossplane's complete
+default allowlist or the minimum verbs for arbitrary kinds.
+
+The workflow is Stable by repository default because the selected current
+documentation contains no explicit non-stable label and it is not tied to a
+served alpha or beta Crossplane API.
+
+# Citations
+
+[1] [Crossplane creates function-produced composed resources with its service account](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L277-L280)
+[2] [Default composed-resource permission scope](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L282-L288)
+[3] [Aggregated ClusterRole procedure and required label](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L290-L321)
+[4] [CloudNativePG ClusterRole example](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L299-L316)
+[5] [RBAC manager default and disable procedures](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/guides/pods.md#L206-L227)
+[6] [RBAC manager responsibilities](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/guides/pods.md#L246-L260)
+[7] [Manual grants required when the RBAC manager is disabled](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/compositions.md#L324-L333)

--- a/catalog/core/index.md
+++ b/catalog/core/index.md
@@ -10,6 +10,7 @@ timestamp: 2026-07-14T00:00:00Z
 * [Composite resource model](composite-resource-model.md) - How XRs, XRDs, Compositions, and composed resources relate in Crossplane v2.
 * [CompositeResourceDefinition v2](composite-resource-definition.md) - The current API for defining composite resource types.
 * [Composition](composition.md) - The current function-pipeline API for composing resources.
+* [Composed-resource RBAC](composed-resource-rbac.md) - Why Crossplane cannot manage every Kubernetes resource kind by default and how to grant additional access.
 * [Real-time composition reconciliation](realtime-composition-reconciliation.md) - Beta composed-resource watches, TTL requeues, required-resource refresh boundaries, and related churn reports.
 * [Namespaced composition boundaries and cross-namespace synchronization](namespaced-composition-cross-namespace-sync.md) - Same-namespace enforcement, issue #6759, and evidence-backed provider or community-controller tradeoffs.
 * [Composition health in GitOps tools](composition-gitops-health.md) - Native status limitations and the documented Argo CD and Flux customization boundaries.

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -8,6 +8,7 @@ timestamp: 2026-07-12T00:00:00Z
 # Catalog Update Log
 
 ## 2026-07-14
+* **Creation**: Documented Crossplane's default composed-resource permission boundary, aggregated ClusterRole grant procedure, and RBAC-manager implications.
 * **Update**: Clarified the one-way effects of deleting or narrowing a ManagedResourceActivationPolicy, the related report in issue #6984, and the dedicated MRAP page's missing explicit warning.
 * **Update**: Clarified with function and Crossplane Core implementation evidence that function-go-templating ExtraResources zero-match lookups are non-fatal and do not impose a minimum result count.
 * **Creation**: Documented Beta real-time composition watches, TTL-driven reconciliation, required-resource refresh boundaries, and six related issue reports with released-fix provenance.


### PR DESCRIPTION
## Summary
- document that Crossplane does not have access to every Kubernetes resource kind by default
- explain the aggregated ClusterRole grant procedure from the v2.3 docs
- distinguish default RBAC manager behavior and disabled-manager responsibilities
- update the Core index, catalog log, and claim ledger

## Validation
- mise run lint
- okf-reviewer: APPROVED

## Source scope
- Crossplane v2.3.3
- Crossplane docs v2.3 at f1315464e35d40d25a28e4c15b6725b0e21adf91