### PR TITLE
docs(okf): research EnvironmentConfig function pipeline

### DIFF
--- a/.agents/agents/okf-function-environment-configs-researcher/AGENT.md
+++ b/.agents/agents/okf-function-environment-configs-researcher/AGENT.md
@@ -1,0 +1,49 @@
+# function-environment-configs User Researcher
+
+Extract source-backed, user-facing knowledge for `crossplane-contrib/function-environment-configs` without editing files.
+
+Return only a compact evidence packet using `.agents/skills/okf/references/evidence-contract.md`.
+
+## Release selection
+
+1. Discover releases and tags at research time.
+2. Select the highest stable semantic-version tag, excluding drafts, prereleases, release candidates, beta tags, alpha tags, and moving branches.
+3. Resolve the selected tag and immediately preceding stable tag to full commit SHAs when available, and record the selected release date.
+4. Cite released source only through immutable commits.
+5. If no stable semantic-version tag exists, report the source as unresolved; never fall back to `main`.
+
+## Default source scope at the selected tag
+
+- `README.md`
+- `package/crossplane.yaml`
+- `fn.go`
+- `fn_test.go`
+- `input/**`
+- `package/input/**`
+- `example/**`
+- `go.mod`
+
+Follow renamed or split files only when they directly establish the same user-visible package, schema, behavior, or example semantics.
+
+## Research focus
+
+- installation and placement in a Composition pipeline
+- the complete function input schema and selector semantics
+- how selected `EnvironmentConfig` data is merged and written to function pipeline context
+- precedence, defaulting, sorting, match limits, errors, and iteration behavior visible to composition authors
+- how later functions, especially `function-go-templating`, consume the resulting context
+- runnable, legacy-free examples and their prerequisites
+- the migration boundary from Crossplane's removed native environment API to this function
+- selected release compatibility evidence and feature-state labels
+
+## Evidence boundaries
+
+- Use implementation, generated schemas, and tests to establish API shape and runtime behavior.
+- Use README and examples to establish documented workflows and user-facing terminology.
+- Treat the historical native API only as migration context. Do not inspect Crossplane Core or infer removal history; the parent assigns Core evidence to dedicated Core researchers.
+- Do not document internal service architecture, contributor workflows, or unrelated SDK APIs.
+- Exclude Claims, claim references, deprecated CompositeResourceDefinition v1 behavior, and legacy v1 composite-resource semantics.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels. Without one, apply the feature-state rules in the evidence contract.
+- Verify the repository license before proposing copied or adapted material; otherwise summarize and cite.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete, install, commit, checkout, or otherwise change repository state. Do not inspect another composition function repository. Do not delegate or write catalog files.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -63,6 +63,25 @@ primary_sources:
       - README section v1 Composite Resources (Legacy)
       - examples requiring Claims or claim references
       - examples requiring deprecated v1 XRD or legacy v1 XR semantics
+  - id: function-environment-configs
+    repository: crossplane-contrib/function-environment-configs
+    kind: function
+    audience: user
+    release_policy: discover-highest-stable-semver-tag
+    agent_set:
+      primary: okf-function-environment-configs-researcher
+    paths:
+      - README.md
+      - package/crossplane.yaml
+      - fn.go
+      - fn_test.go
+      - input
+      - package/input
+      - examples
+      - go.mod
+    legacy_exclusions:
+      - examples requiring Claims or claim references
+      - examples requiring deprecated v1 XRD or legacy v1 XR semantics
   - id: xprin
     repository: crossplane-contrib/xprin
     kind: composition-test-tool

--- a/.codex/agents/okf-function-environment-configs-researcher.toml
+++ b/.codex/agents/okf-function-environment-configs-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-environment-configs-researcher"
+description = "Read-only user-facing researcher dedicated to crossplane-contrib/function-environment-configs."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-environment-configs-researcher/AGENT.md` as the canonical role instructions."

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -1,6 +1,6 @@
 ---
 type: Evidence Ledger
-title: function-go-templating v0.12.2 claim ledger
+title: Crossplane catalog claim ledger
 ---
 
 # Scope
@@ -15,6 +15,24 @@ evidence for this Crossplane catalog and primary implementation evidence only
 for its own API and controller behavior. The integration example is adapted,
 not copied; both Sveltos repositories and both Crossplane functions are
 Apache-2.0 licensed.
+
+## EnvironmentConfig lifecycle and three-function pipeline
+
+Selected Core releases: v1.17.3 at `481d3ca7193c89708b9a40375381862d25d64006`, v1.18.0 at `e663a43ece850e93fe5cdebb2e478e2fb9762ad1`, and current v2.3.3 at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`. Current documentation is v2.3 at `f1315464e35d40d25a28e4c15b6725b0e21adf91`; historical v1.18 documentation is pinned at `ad7f75a96dc902b1cdfee213255d87612fccbdbe`. Selected function releases are environment-configs v0.7.2 at `5589092483aea1d65b9988f5116106585c4b516b`, go-templating v0.12.2 at `0a1e6d386f4363fae257ddbfb5b497416370e830`, and auto-ready v0.7.0 at `ed7886de159af73b9d6976f04f9171ec7a4cb411`. Claims, deprecated XRD v1, legacy XR semantics, and old Resource-mode examples were excluded.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| environment-config | EnvironmentConfig remains a cluster-scoped schemaless data API in v2.3.3 and serves only v1beta1. | API | primary and official-documentation | corroborated | Beta; [CRD](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml#L7-L62) |
+| native-composition-environment-removal | v1.18 removed native Alpha Composition selection/loading/environment patches, not the EnvironmentConfig resource. | API and release-history | primary and official-documentation | corroborated | Removed capability; [old Alpha field](https://github.com/crossplane/crossplane/blob/481d3ca7193c89708b9a40375381862d25d64006/apis/apiextensions/v1/composition_types.go#L62-L68), [migration docs](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/environment-configs.md#L78-L96) |
+| environment-configs-package | function-environment-configs v0.7.2 requires Crossplane 2.x and writes merged data to the standard environment context key. | API and behavior | primary | direct | Beta input ceiling; [metadata](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/package/crossplane.yaml#L10-L25) |
+| environment-configs-input | Input supports default data, ordered references or selectors, Single/Multiple cardinality, label matchers, sorting, and Required/Optional resolution. | API | primary | direct | Beta; [types](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L24-L238) |
+| environment-configs-input | Runtime types and tests support toFieldPath but the packaged schema omits it, so safe packaged use is unresolved. | API conflict | primary | corroborated | Beta context; [type](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L115-L118), [schema](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml#L70-L165) |
+| selection-and-merge | Later selected data overrides earlier data, selected data overrides defaults, and defaults override incoming environment context; maps merge recursively. | behavior | primary | corroborated | Beta; [runtime](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L101-L120) |
+| go-templating-environment-source | Environment source requires a string at the named key beneath the reserved environment context; missing or wrong-typed values are fatal before template parsing. | API and behavior | primary | direct | Beta input ceiling; [loader](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/template.go#L103-L122) |
+| auto-ready-environment-context | Alpha CEL rules may load from a bracket-and-dot environment context path; inline rules override context rules and parser/type misses are silently ignored. | API and behavior | primary | corroborated | Explicit Alpha; [merge](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L100), [parser](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L203-L255) |
+| environment-config-pipeline | Function ordering follows data dependencies: environment-configs precedes a context-consuming template; auto-ready follows resource-producing steps and optional context producers. | illustrative-pattern and behavior | primary function repositories and official-documentation | corroborated | Alpha when CEL customizations or Alpha Context mutation are used; [example](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck/composition.yaml#L10-L48) |
+
+Unresolved: the packaged `toFieldPath` schema conflict; stale v1alpha1 auto-ready README snippets versus the served v1beta1 input; old go-templating environment example pins and legacy XRD companion material. No project-history or design evidence was used for this batch.
 
 # Claims
 

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -5,11 +5,29 @@ sources:
     tag: v2.3.3
     commit: 09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d
     resolved_at: 2026-07-14
+  crossplane-v1.17:
+    repository: crossplane/crossplane
+    tag: v1.17.3
+    commit: 481d3ca7193c89708b9a40375381862d25d64006
+    selected_by: native Composition environment removal boundary
+    resolved_at: 2026-07-14
+  crossplane-v1.18:
+    repository: crossplane/crossplane
+    tag: v1.18.0
+    commit: e663a43ece850e93fe5cdebb2e478e2fb9762ad1
+    selected_by: native Composition environment removal boundary
+    resolved_at: 2026-07-14
   crossplane-docs:
     repository: crossplane/docs
     series: v2.3
     commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
     selected_by: crossplane/v2.3.3
+    resolved_at: 2026-07-14
+  crossplane-docs-v1.18:
+    repository: crossplane/docs
+    series: v1.18
+    commit: ad7f75a96dc902b1cdfee213255d87612fccbdbe
+    selected_by: historical migration documentation
     resolved_at: 2026-07-14
   argo-cd:
     repository: argoproj/argo-cd
@@ -43,6 +61,13 @@ sources:
     commit: 0a1e6d386f4363fae257ddbfb5b497416370e830
     previous_tag: v0.12.1
     previous_commit: 548ae34fd9c843f0747981894fb7fa0ff1ba47fa
+    resolved_at: 2026-07-14
+  function-environment-configs:
+    repository: crossplane-contrib/function-environment-configs
+    tag: v0.7.2
+    commit: 5589092483aea1d65b9988f5116106585c4b516b
+    previous_tag: v0.7.1
+    previous_commit: 054a6b8d08ae3e0c957a0e75359b14f88340ca39
     resolved_at: 2026-07-14
   function-auto-ready:
     repository: crossplane-contrib/function-auto-ready

--- a/.pi/agents/okf-function-environment-configs-researcher.md
+++ b/.pi/agents/okf-function-environment-configs-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-environment-configs-researcher
+description: Read-only user-facing researcher dedicated to crossplane-contrib/function-environment-configs.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-environment-configs-researcher/AGENT.md` as the canonical role instructions.

--- a/catalog/core/environment-config.md
+++ b/catalog/core/environment-config.md
@@ -1,0 +1,58 @@
+---
+type: api
+title: EnvironmentConfig
+description: Beta cluster-scoped data resources retained after native Composition environment integration was removed.
+resource: https://github.com/crossplane/crossplane
+tags: [crossplane, environment-config, composition, beta]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane/crossplane
+source_tag: v2.3.3
+source_commit: 09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d
+source_paths:
+  - cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml
+  - apis/apiextensions/v1beta1/environment_config_types.go
+documentation_repository: crossplane/docs
+documentation_series: v2.3
+documentation_commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
+feature_state: Beta
+feature_state_basis: The current CRD serves only apiextensions.crossplane.io/v1beta1 and official v2.3 documentation explicitly labels the API Beta.
+---
+
+# Overview
+
+`EnvironmentConfig` remains a cluster-scoped Crossplane resource in v2.3.3. It
+has an optional schemaless `data` object for arbitrary JSON-compatible values,
+plural `environmentconfigs`, and short name `envcfg`.[1][2]
+
+The resource is not a native Composition selector or merge engine. Current
+pipelines use
+[function-environment-configs](../functions/function-environment-configs/) to
+retrieve selected objects, merge their data, and place the result in function
+context.[3]
+
+# API lifecycle
+
+| Release | Served and storage versions | Meaning |
+|---|---|---|
+| v1.17.3 | `v1alpha1` served and storage | Alpha resource used by the then-native Alpha Composition environment integration.[4] |
+| v1.18.0 | `v1alpha1` served for compatibility; `v1beta1` served and storage | The resource was promoted while native Composition integration was removed.[5] |
+| v2.3.3 | `v1beta1` served and storage | Current retained Beta API.[1] |
+
+Official v2.3 documentation describes the in-memory environment as unique to
+an XR and unavailable to other XRs. That statement concerns the per-run
+pipeline context assembled from shared cluster-scoped resources, not isolation
+of the `EnvironmentConfig` objects themselves.[3]
+
+# Limitations
+
+- Do not say that Crossplane v1.18 removed the `EnvironmentConfig` API. It removed native selection, loading, and environment patching.
+- The schemaless `data` field does not validate application-specific structure. Downstream functions define any required keys and value types.
+- Current documentation sometimes says Crossplane merges referenced EnvironmentConfigs as shorthand; its detailed workflow and released implementation attribute retrieval and merging to the function.[3]
+
+# Citations
+
+[1] [Crossplane v2.3.3 EnvironmentConfig CRD](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml#L7-L62)
+[2] [Crossplane v2.3.3 v1beta1 type](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/apis/apiextensions/v1beta1/environment_config_types.go#L24-L44)
+[3] [Crossplane v2.3 Environment Configs documentation](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/environment-configs.md#L1-L34)
+[4] [Crossplane v1.17.3 EnvironmentConfig CRD](https://github.com/crossplane/crossplane/blob/481d3ca7193c89708b9a40375381862d25d64006/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml#L7-L63)
+[5] [Crossplane v1.18.0 multi-version EnvironmentConfig CRD](https://github.com/crossplane/crossplane/blob/e663a43ece850e93fe5cdebb2e478e2fb9762ad1/cluster/crds/apiextensions.crossplane.io_environmentconfigs.yaml#L20-L104)

--- a/catalog/core/index.md
+++ b/catalog/core/index.md
@@ -10,6 +10,8 @@ timestamp: 2026-07-14T00:00:00Z
 * [Composite resource model](composite-resource-model.md) - How XRs, XRDs, Compositions, and composed resources relate in Crossplane v2.
 * [CompositeResourceDefinition v2](composite-resource-definition.md) - The current API for defining composite resource types.
 * [Composition](composition.md) - The current function-pipeline API for composing resources.
+* [EnvironmentConfig](environment-config.md) - The retained Beta cluster-scoped data API consumed by environment-aware functions.
+* [Native Composition environment removal](native-composition-environment-removal.md) - The v1.18 removal and migration boundary without conflating it with the retained resource API.
 * [Composed-resource RBAC](composed-resource-rbac.md) - Why Crossplane cannot manage every Kubernetes resource kind by default and how to grant additional access.
 * [Real-time composition reconciliation](realtime-composition-reconciliation.md) - Beta composed-resource watches, TTL requeues, required-resource refresh boundaries, and related churn reports.
 * [Namespaced composition boundaries and cross-namespace synchronization](namespaced-composition-cross-namespace-sync.md) - Same-namespace enforcement, issue #6759, and evidence-backed provider or community-controller tradeoffs.

--- a/catalog/core/native-composition-environment-removal.md
+++ b/catalog/core/native-composition-environment-removal.md
@@ -1,0 +1,67 @@
+---
+type: concept
+title: Native Composition environment removal
+description: The v1.18 boundary that removed Alpha native environment integration while retaining EnvironmentConfig resources.
+resource: https://github.com/crossplane/crossplane/releases/tag/v1.18.0
+tags: [crossplane, composition, environment-config, migration, removed]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane/crossplane
+source_tag: v1.18.0
+source_commit: e663a43ece850e93fe5cdebb2e478e2fb9762ad1
+source_paths:
+  - apis/apiextensions/v1/composition_types.go
+  - apis/apiextensions/v1/composition_patches.go
+  - cmd/crossplane/core/core.go
+supporting_source_tag: v1.17.3
+supporting_source_commit: 481d3ca7193c89708b9a40375381862d25d64006
+documentation_repository: crossplane/docs
+documentation_series: v2.3
+documentation_commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
+feature_state: Removed
+feature_state_basis: Crossplane v1.17.3 explicitly marked Composition.spec.environment Alpha; released v1.18 source removed the field and rejects its former feature flag.
+---
+
+# Removal boundary
+
+Crossplane v1.17.3 exposed an explicitly Alpha, feature-gated
+`Composition.spec.environment`. It supported `defaultData`, ordered reference
+or selector sources, pre-render environment patches, and a resolution
+policy.[1][2] Patch-and-Transform also exposed four environment patch types.[3]
+
+Crossplane v1.18 removed that native Composition integration:
+
+- `spec.environment` and its native selectors disappeared;[4]
+- `FromEnvironmentFieldPath`, `ToEnvironmentFieldPath`,
+  `CombineFromEnvironment`, and `CombineToEnvironment` disappeared from native
+  Composition patches;[5]
+- the old `--enable-environment-configs` flag became an error directing users
+  to `function-environment-configs`.[6]
+
+The [EnvironmentConfig resource](environment-config.md) was retained and
+promoted to a `v1beta1` storage API. Crossplane v2.3.3 continues this boundary:
+Composition is pipeline-only and has no native environment field or
+environment patch types.[7]
+
+# Migration
+
+Official guidance converts Resource-mode Compositions to function pipelines.
+Environment selection fields map to `function-environment-configs`; former
+environment patching moves to a downstream function such as
+`function-patch-and-transform`.[8]
+
+The selected current `function-environment-configs` release requires Crossplane 2.x. This catalog therefore documents the v1.18 change as historical migration context, not as a claim that function v0.7.2 runs on Crossplane 1.x.
+
+# Exclusions
+
+Claims, deprecated XRD v1 schema, legacy v1 XR semantics, and old Resource-mode manifests are not reproduced. The removed field and patch names appear only so migration tooling and historical configurations can be recognized.
+
+# Citations
+
+[1] [v1.17.3 explicit Alpha Composition field](https://github.com/crossplane/crossplane/blob/481d3ca7193c89708b9a40375381862d25d64006/apis/apiextensions/v1/composition_types.go#L62-L68)
+[2] [v1.17.3 native environment schema](https://github.com/crossplane/crossplane/blob/481d3ca7193c89708b9a40375381862d25d64006/apis/apiextensions/v1/composition_environment.go#L29-L60)
+[3] [v1.17.3 environment patch types](https://github.com/crossplane/crossplane/blob/481d3ca7193c89708b9a40375381862d25d64006/apis/apiextensions/v1/composition_patches.go#L29-L42)
+[4] [v1.18.0 CompositionSpec without native environment](https://github.com/crossplane/crossplane/blob/e663a43ece850e93fe5cdebb2e478e2fb9762ad1/apis/apiextensions/v1/composition_types.go#L23-L62)
+[5] [v1.18.0 native patch types after removal](https://github.com/crossplane/crossplane/blob/e663a43ece850e93fe5cdebb2e478e2fb9762ad1/apis/apiextensions/v1/composition_patches.go#L29-L105)
+[6] [v1.18.0 rejected legacy feature flag](https://github.com/crossplane/crossplane/blob/e663a43ece850e93fe5cdebb2e478e2fb9762ad1/cmd/crossplane/core/core.go#L220-L224)
+[7] [v2.3.3 pipeline-only CompositionSpec](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/apis/apiextensions/v1/composition_types.go#L23-L60)
+[8] [Official v2.3 removal and migration guidance](https://github.com/crossplane/docs/blob/f1315464e35d40d25a28e4c15b6725b0e21adf91/content/v2.3/composition/environment-configs.md#L78-L144)

--- a/catalog/functions/environment-config-pipeline.md
+++ b/catalog/functions/environment-config-pipeline.md
@@ -1,0 +1,65 @@
+---
+type: example
+title: EnvironmentConfig, Go templating, and readiness pipeline
+description: Evidence-backed ordering and data flow across function-environment-configs, function-go-templating, and function-auto-ready.
+resource: https://github.com/crossplane-contrib/function-auto-ready/tree/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck
+tags: [crossplane, composition, environment-config, go-template, readiness]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-auto-ready
+source_commit: ed7886de159af73b9d6976f04f9171ec7a4cb411
+source_paths:
+  - example/cel-healthcheck/composition.yaml
+  - example/cel-healthcheck/extra-resources.yaml
+supporting_source_repositories:
+  - crossplane-contrib/function-environment-configs
+  - crossplane-contrib/function-go-templating
+feature_state: Alpha
+feature_state_basis: The full pattern uses function-auto-ready CELHealthcheckCustomizations, which is explicitly Alpha and disabled by default.
+---
+
+# Data flow
+
+The three functions have separate responsibilities and must be ordered by their data dependencies:
+
+1. `function-environment-configs` selects Beta `EnvironmentConfig` objects and writes the merged map to `apiextensions.crossplane.io/environment`.
+2. `function-go-templating` reads the map directly or loads template text with `source: Environment`, then produces desired composed resources and may publish Alpha Context updates.
+3. `function-auto-ready` evaluates desired resources against their observed counterparts. Its optional Alpha CEL feature may also load rules from the environment context.[1][2][3]
+
+The selected auto-ready example uses the order go-templating →
+environment-configs → auto-ready because the template is inline and does not
+consume the environment. If template text or rendering data comes from an
+EnvironmentConfig, environment-configs must instead precede go-templating.
+Auto-ready remains last because it consumes the desired resource and optional
+context produced earlier.[1][4]
+
+# Environment-supplied CEL rules
+
+The current example stores a Configuration readiness expression at:
+
+`data.celHealthCheckCustomizations.pkg.crossplane.io_v1_Configuration`
+
+Auto-ready reads it with:
+
+`[apiextensions.crossplane.io/environment].celHealthCheckCustomizations`
+
+The rule requires the observed package to have `Installed=True` and `Healthy=True`.[1][5]
+
+# Adaptation boundary
+
+This page summarizes repository-owned Apache-2.0 examples; it does not reproduce a complete manifest set.
+
+- The auto-ready v0.7.0 CEL example uses current `EnvironmentConfig/v1beta1` and `Input/v1beta1` and is the preferred basis for the readiness integration.[1][5]
+- The go-templating environment example demonstrates Environment source and
+  all three functions, but pins older function packages, uses
+  `EnvironmentConfig/v1alpha1`, includes legacy XRD `connectionSecretKeys`, and
+  configures local Development runtime. Do not apply it unchanged.[6]
+- A v2 adaptation should use current namespaced or cluster-scoped v2 XR semantics, current function tags, `EnvironmentConfig/v1beta1`, and matching Function object names.
+
+# Citations
+
+[1] [Current auto-ready three-function composition](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck/composition.yaml#L10-L48)
+[2] [function-environment-configs context output](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L101-L134)
+[3] [function-go-templating Environment loader](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/template.go#L103-L122)
+[4] [auto-ready desired and observed resource ordering](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L81-L119)
+[5] [Current v1beta1 EnvironmentConfig CEL rule](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/example/cel-healthcheck/extra-resources.yaml#L1-L7)
+[6] [Older go-templating environment pipeline snapshot](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/example/environment/composition.yaml#L1-L36)

--- a/catalog/functions/function-auto-ready/cel-health-checks.md
+++ b/catalog/functions/function-auto-ready/cel-health-checks.md
@@ -59,6 +59,19 @@ only: each expression still receives its matched observed composed resource as
 `object`. Inline rules remain useful for Composition-specific overrides because
 they replace same-key context rules.[2][3]
 
+# Context path behavior
+
+The local path parser preserves dots inside unquoted bracket segments, then
+traverses dot-separated keys. A missing key or non-map intermediate silently
+yields no context rules. At the terminal map, non-string values are silently
+dropped.[9][10]
+
+The parser reports an error only when it extracts no segments and does not
+require the entire input to match. Use the documented bracket form exactly;
+malformed punctuation may otherwise be partially ignored.[9]
+
+See the [three-function environment pipeline](../environment-config-pipeline.md) for ordering and adaptation guidance.
+
 # Limitations
 
 The README says an evaluation error is treated as not ready and that a customization takes precedence over a built-in check.
@@ -77,3 +90,5 @@ The README's CEL snippets use `v1alpha1`, conflicting with the selected [v1beta1
 [6] [README error and precedence description](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L85-L91)
 [7] [Runtime error fallthrough](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L119-L159)
 [8] [README v1alpha1 snippets](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/README.md#L100-L129)
+[9] [Local bracket-and-dot path parser](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L238-L255)
+[10] [Context traversal and string-map conversion](https://github.com/crossplane-contrib/function-auto-ready/blob/ed7886de159af73b9d6976f04f9171ec7a4cb411/fn.go#L203-L235)

--- a/catalog/functions/function-environment-configs/index.md
+++ b/catalog/functions/function-environment-configs/index.md
@@ -1,0 +1,12 @@
+---
+type: index
+title: function-environment-configs index
+description: Progressive index for function-environment-configs v0.7.2.
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# function-environment-configs v0.7.2
+
+* [Function package](package.md) - Install and place the Crossplane 2.x function before context consumers.
+* [Input](input.md) - Configure default data, references, selectors, cardinality, sorting, and resolution.
+* [Selection and merge behavior](selection-and-merge.md) - Understand function iterations, precedence, deep merging, context output, and errors.

--- a/catalog/functions/function-environment-configs/input.md
+++ b/catalog/functions/function-environment-configs/input.md
@@ -1,0 +1,61 @@
+---
+type: functioninput
+title: function-environment-configs Input v1beta1
+description: Default environment data, ordered EnvironmentConfig references or selectors, cardinality, sorting, and resolution.
+resource: https://github.com/crossplane-contrib/function-environment-configs
+tags: [crossplane, function, environment-config, schema, beta]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-environment-configs
+source_tag: v0.7.2
+source_commit: 5589092483aea1d65b9988f5116106585c4b516b
+source_paths:
+  - input/v1beta1/composition_environment.go
+  - package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
+feature_state: Beta
+feature_state_basis: The packaged schema serves and stores environmentconfigs.fn.crossplane.io/v1beta1.
+---
+
+# Schema
+
+`spec.defaultData` is the initial schemaless environment. `spec.environmentConfigs` is an ordered list of sources whose selected data overrides defaults.[1]
+
+| Field | Meaning |
+|---|---|
+| `environmentConfigs[].type` | `Reference` or `Selector`; defaults to `Reference`. |
+| `ref.name` | Exact EnvironmentConfig name for a reference. |
+| `selector.mode` | `Single` or `Multiple`; defaults to `Single`. |
+| `selector.minMatch` | Minimum accepted matches in Multiple mode. |
+| `selector.maxMatch` | Maximum retained matches after sorting in Multiple mode. |
+| `selector.sortByFieldPath` | Ascending sort path; defaults to `metadata.name`. |
+| `selector.matchLabels[]` | Label key plus literal `Value` or default `FromCompositeFieldPath` source. |
+| `policy.resolution` | `Required` by default; `Optional` permits a missing named reference. |
+
+A composite-field matcher is Required by default. With
+`policy.resolution: Optional`, a missing XR field skips that matcher; if every
+matcher is skipped, the source generates no resource request.[2][3][4]
+
+The former native `policy.resolve` option is not exposed; the function resolves sources on every invocation.[5]
+
+# Schema conflict: toFieldPath
+
+Go input types and runtime tests support `environmentConfigs[].toFieldPath`, which groups selected data beneath a destination path. The distributed packaged schema omits this field.[6][7]
+
+Do not rely on `toFieldPath` in package-validated input until that disagreement is resolved. Even where runtime decoding accepts it, Kubernetes or package schema validation may prune or reject it.
+
+# Stale source comments
+
+Some inherited comments say resolved references are written to
+`spec.environmentConfigRefs` and consumed through environment patches. The
+released function writes only pipeline context; it does not update XR spec.
+Follow [selection and merge behavior](selection-and-merge.md), not those
+historical comments.
+
+# Citations
+
+[1] [Default data and source list](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L24-L43)
+[2] [Reference, selector, cardinality, and sorting types](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L87-L182)
+[3] [Label value sources and field-resolution policy](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L184-L238)
+[4] [Optional field-path matchers and all-skipped selector behavior](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L317-L360)
+[5] [Resolution policy and unsupported resolve option](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L47-L84)
+[6] [Runtime toFieldPath input](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/input/v1beta1/composition_environment.go#L115-L118)
+[7] [Packaged input schema source properties](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml#L70-L165)

--- a/catalog/functions/function-environment-configs/package.md
+++ b/catalog/functions/function-environment-configs/package.md
@@ -1,0 +1,44 @@
+---
+type: function
+title: function-environment-configs
+description: Retrieve and merge EnvironmentConfig resources into Composition function pipeline context.
+resource: https://github.com/crossplane-contrib/function-environment-configs
+tags: [crossplane, function, environment-config, composition]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-environment-configs
+source_tag: v0.7.2
+source_commit: 5589092483aea1d65b9988f5116106585c4b516b
+source_paths: [README.md, package/crossplane.yaml, go.mod]
+feature_state: Beta
+feature_state_basis: The packaged function input serves environmentconfigs.fn.crossplane.io/v1beta1, which imposes a Beta ceiling.
+---
+
+# Overview
+
+`function-environment-configs` is a Composition Function that requests
+cluster-scoped [EnvironmentConfig](../../core/environment-config.md) resources,
+merges their data, and writes the result to pipeline context at
+`apiextensions.crossplane.io/environment`.[1]
+
+The selected stable release is v0.7.2 at
+`5589092483aea1d65b9988f5116106585c4b516b`; v0.7.1 is pinned at
+`054a6b8d08ae3e0c957a0e75359b14f88340ca39`.
+
+# Compatibility and placement
+
+Package metadata and the README require Crossplane `>=v2.0.0-0`; do not deploy this release on Crossplane 1.x.[2][3]
+
+Place it before every step that needs the merged environment. Typical consumers are:
+
+- [function-go-templating Environment source](../function-go-templating/environment-source.md), direct `.context` reads, or Alpha Context updates;
+- [function-auto-ready CEL customizations](../function-auto-ready/cel-health-checks.md) loaded from an environment context path.
+
+# Limitations
+
+- Build-time module versions do not establish a broader compatibility guarantee than the package's explicit Crossplane constraint.
+
+# Citations
+
+[1] [Package description and context key](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/package/crossplane.yaml#L10-L20)
+[2] [Package Crossplane version constraint and capability](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/package/crossplane.yaml#L21-L25)
+[3] [README Crossplane 2.x warning](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/README.md#L5-L7)

--- a/catalog/functions/function-environment-configs/selection-and-merge.md
+++ b/catalog/functions/function-environment-configs/selection-and-merge.md
@@ -1,0 +1,66 @@
+---
+type: function
+title: EnvironmentConfig selection and merge behavior
+description: Iterative resource requests, selector cardinality, sorting, deep-merge precedence, context output, and failure behavior.
+resource: https://github.com/crossplane-contrib/function-environment-configs
+tags: [crossplane, function, environment-config, context, merge]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-environment-configs
+source_tag: v0.7.2
+source_commit: 5589092483aea1d65b9988f5116106585c4b516b
+source_paths: [fn.go, fn_test.go]
+feature_state: Beta
+feature_state_basis: The function input and selected EnvironmentConfig API are v1beta1.
+---
+
+# Function iterations
+
+Each configured source becomes a required-resource request named
+`environment-config-<input-index>` for
+`apiextensions.crossplane.io/v1beta1`, kind `EnvironmentConfig`, matched by name
+or labels. The function returns requirements on every invocation; when results
+are not yet present, it returns without writing environment context.[1]
+
+Reference mode accepts exactly one object. A required zero match or more than one returned object is fatal; an Optional zero match is skipped.[2]
+
+Selector behavior is:
+
+- `Single` requires exactly one returned object.
+- `Multiple` validates `minMatch`, sorts ascending, then truncates to `maxMatch`.
+- Sorting accepts consistently typed strings, integers, or floating-point values. Mixed or unsupported types error. Missing paths use the chosen type's zero value; if all paths are absent, incoming order remains.[3]
+
+# Merge precedence
+
+The function recursively merges maps and replaces conflicting non-map values. Higher-precedence values are:
+
+1. later selected EnvironmentConfigs over earlier selected EnvironmentConfigs;
+2. selected EnvironmentConfig data over `defaultData`;
+3. `defaultData` over an incoming environment already present in request context.[4]
+
+The result is written at `apiextensions.crossplane.io/environment`. When the merged map has no GVK fields, the function adds `apiVersion: internal.crossplane.io/v1alpha1` and `kind: Environment` inside the context value.[5]
+
+For sources sharing one `toFieldPath`, source and sorted match order are
+retained. Across distinct overlapping destination buckets, the implementation
+iterates a Go map, so relative overwrite order is unspecified. This is another
+reason not to depend on the currently schema-conflicted field.[6]
+
+# Failure behavior
+
+Invalid input, observed XR decoding, selector construction, returned-resource
+decoding, selection, sorting, merging, or protobuf conversion produces a fatal
+function result. Missing required resources during the normal requirements
+iteration are not fatal until a returned result establishes a zero-match case
+subject to the selected policy.[1][2][3]
+
+# Relationships
+
+Later steps can consume the output through [function-go-templating](../function-go-templating/environment-source.md) or the Alpha [function-auto-ready CEL context source](../function-auto-ready/cel-health-checks.md).
+
+# Citations
+
+[1] [Requirement construction and iteration return](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L64-L77)
+[2] [Reference and selector cardinality](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L178-L218)
+[3] [Sorting implementation](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L221-L315)
+[4] [Merge inputs and precedence](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L101-L120)
+[5] [Context key and output GVK](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L122-L134)
+[6] [Destination grouping and map iteration](https://github.com/crossplane-contrib/function-environment-configs/blob/5589092483aea1d65b9988f5116106585c4b516b/fn.go#L138-L175)

--- a/catalog/functions/function-go-templating/environment-source.md
+++ b/catalog/functions/function-go-templating/environment-source.md
@@ -1,0 +1,58 @@
+---
+type: functioninput
+title: Environment template source in function-go-templating
+description: Load a Go template string from the reserved environment pipeline-context map.
+resource: https://github.com/crossplane-contrib/function-go-templating
+tags: [crossplane, function, go-template, environment-config, context]
+timestamp: 2026-07-14T00:00:00Z
+source_repository: crossplane-contrib/function-go-templating
+source_tag: v0.12.2
+source_commit: 0a1e6d386f4363fae257ddbfb5b497416370e830
+source_paths:
+  - package/input/gotemplating.fn.crossplane.io_gotemplates.yaml
+  - template.go
+  - fn.go
+feature_state: Beta
+feature_state_basis: The Environment source is configured through the served and stored gotemplating.fn.crossplane.io/v1beta1 GoTemplate input.
+---
+
+# Schema and lookup
+
+Configure `source: Environment` with `environment.key`. Runtime reads exactly `context["apiextensions.crossplane.io/environment"][key]` and requires the result to be a string.[1]
+
+```yaml
+apiVersion: gotemplating.fn.crossplane.io/v1beta1
+kind: GoTemplate
+source: Environment
+environment:
+  key: template
+```
+
+The generated schema requires only `source`; it does not enumerate source values or conditionally require `environment.key`. Runtime supplies the missing validation.[2]
+
+# Errors
+
+A missing `environment.key`, absent reserved context, absent nested key, non-map environment, or non-string template value becomes a fatal `invalid function input` result before template parsing.[1][3]
+
+Template `missingkey` options do not affect source lookup because they apply later during template execution. They only govern missing data accessed by the loaded template.[3]
+
+# Direct data access and updates
+
+An Inline or FileSystem template can still read environment values directly
+with `index .context "apiextensions.crossplane.io/environment" ...`;
+Environment source is needed only when the template text itself is stored in
+the environment.[4]
+
+The Alpha rendered `Context` instruction can deep-merge updates under the same reserved key. See [Context](context.md) for its separate Alpha feature state and same-invocation overwrite limitations.[5]
+
+# Relationships
+
+[function-environment-configs](../function-environment-configs/) must run first to select and merge EnvironmentConfigs. [function-auto-ready](../function-auto-ready/) may run after resource rendering when its readiness behavior is needed.
+
+# Citations
+
+[1] [Environment source lookup and validation](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/template.go#L103-L122)
+[2] [Generated GoTemplate input schema](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/package/input/gotemplating.fn.crossplane.io_gotemplates.yaml#L18-L94)
+[3] [Source retrieval, parsing, options, and fatal execution paths](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/fn.go#L82-L117)
+[4] [README direct environment context expression](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/README.md#L60-L68)
+[5] [README environment Context update](https://github.com/crossplane-contrib/function-go-templating/blob/0a1e6d386f4363fae257ddbfb5b497416370e830/README.md#L241-L277)

--- a/catalog/functions/function-go-templating/index.md
+++ b/catalog/functions/function-go-templating/index.md
@@ -9,6 +9,7 @@ timestamp: 2026-07-14T00:00:00Z
 
 * [Package and installation](package.md) - Install and reference the selected stable function package.
 * [GoTemplate input](input.md) - Author Inline, FileSystem, or Environment input using the generated schema.
+* [Environment template source](environment-source.md) - Load template text from the reserved EnvironmentConfig pipeline-context map.
 * [Request data and context](request-data.md) - Read request state, extra resources, context, and credentials.
 * [Context](context.md) - Read, create, and deeply update shared function-pipeline context.
 * [ExtraResources](extra-resources.md) - Request cluster resources by name or labels and consume them directly or through pipeline context.

--- a/catalog/functions/function-go-templating/input.md
+++ b/catalog/functions/function-go-templating/input.md
@@ -8,7 +8,8 @@ timestamp: 2026-07-12T00:00:00Z
 source_repository: crossplane-contrib/function-go-templating
 source_tag: v0.12.2
 source_commit: 0a1e6d386f4363fae257ddbfb5b497416370e830
-feature_state: Not stated by selected sources
+feature_state: Beta
+feature_state_basis: The generated CRD serves and stores only gotemplating.fn.crossplane.io/v1beta1.
 ---
 
 # Schema
@@ -35,7 +36,7 @@ The README example nests `options` beneath `inline`, but the generated CRD place
 Follow the generated schema.
 The only bundled FileSystem example depends on excluded legacy Claim/XRD semantics, so this catalog does not present it as a runnable v2 example.
 
-Feature maturity is **Not stated by selected sources**.
+The overall input is Beta because its only served and stored version is `v1beta1`. Capabilities implemented through separate `v1alpha1` meta instructions, such as Context, retain their Alpha ceilings.
 
 # Citations
 

--- a/catalog/functions/index.md
+++ b/catalog/functions/index.md
@@ -15,8 +15,10 @@ timestamp: 2026-07-12T00:00:00Z
 * [Composition functions](composition-functions.md) - Continuously reconcile XRs through ordered Composition pipelines.
 * [Composition Functions specification](composition-function-specification.md) - Normative contract for serving, desired state, packaging, and runtime assumptions.
 
+* [function-environment-configs](function-environment-configs/) - Select and merge EnvironmentConfigs into pipeline context.
 * [function-go-templating](function-go-templating/) - Render desired resources from Go templates in a composition pipeline.
 * [function-auto-ready](function-auto-ready/) - Determine desired composed-resource readiness from observed resources.
+* [EnvironmentConfig, Go templating, and readiness pipeline](environment-config-pipeline.md) - Order the three functions by their context and desired-resource dependencies.
 
 # Operation Functions
 

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -9,6 +9,10 @@ timestamp: 2026-07-12T00:00:00Z
 
 ## 2026-07-14
 * **Creation**: Added manual composed-resource readiness patterns and a release-pinned Sveltos Profile-to-ClusterSummary ExtraResources example.
+* **Creation**: Added release-pinned EnvironmentConfig knowledge covering the
+  retained Beta API, the v1.18 removal of native Composition integration,
+  function-environment-configs v0.7.2 selection and merge behavior, and the
+  environment-to-template-to-readiness pipeline.
 * **Correction**: Clarified from function-go-templating v0.12.2 conversion
   code and tests that ExtraResources `matchLabels` works for cluster-scoped
   resources; the defect is lost namespace scoping, which turns `matchLabels`


### PR DESCRIPTION
## Summary
- distinguish the retained Beta EnvironmentConfig API from the native Composition environment integration removed in Crossplane v1.18
- add release-pinned function-environment-configs v0.7.2 package, input, selection, merge, and migration knowledge
- document the environment-configs, go-templating, and auto-ready pipeline relationships and known schema/version conflicts
- add the dedicated function-environment-configs researcher profile and source locks

## Validation
- mise run lint (58 concepts, 0 errors, 0 warnings)
- okf-reviewer: APPROVED
- git diff --check