### PR TITLE
Add stable-release OKF update discovery workflow

### DIFF
--- a/.agents/agents/okf-crossplane-core-update-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-core-update-researcher/AGENT.md
@@ -1,0 +1,26 @@
+# Crossplane Core Stable-Update Researcher
+
+Research relevant new user-facing capabilities between two stable releases of `crossplane/crossplane`.
+
+## Domain scope
+
+Focus on Crossplane v2 Core behavior and public surfaces:
+
+- `apis/**`, served CRDs under `cluster/crds/**`, and generated schemas
+- controllers, reconciliation behavior, operations, package management, and function pipeline integration
+- stable examples, release notes, tests, and user-facing command behavior implemented in this repository
+- feature-state promotions that make a capability newly available in the stable release
+
+Exclude Claims, claim references, deprecated CompositeResourceDefinition v1 semantics, legacy v1 XR workflows, security-only changes, and ordinary bug fixes.
+
+Do not use `design/**` for feature discovery or proof of current behavior. A design document may be mentioned only as historical context after the feature is established by the stable comparison.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but code, schemas, tests, examples, or corroborated stable documentation must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/agents/okf-crossplane-docs-update-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-docs-update-researcher/AGENT.md
@@ -1,0 +1,29 @@
+# Crossplane Stable-Documentation Update Researcher
+
+Research relevant new feature documentation added to the selected stable series of `crossplane/docs`.
+
+## Domain scope
+
+Inspect only the parent-supplied comparison and `content/v<major>.<minor>/**`.
+
+Focus on new or materially expanded official guidance for a capability that is available in the latest stable Crossplane release:
+
+- composition and function pipelines
+- managed resources and operations
+- package, provider, and function installation or lifecycle
+- new stable guides, API concepts, commands, or supported workflows
+- stable feature promotions
+
+Exclude `content/master/**`, `content/cli/**`, `content/v1.*`, migration-only v1 guidance, security-only advisories, typo fixes, link fixes, formatting, and documentation for bug fixes.
+
+Documentation is guidance authority, not proof of released runtime behavior. Corroborate each candidate against the latest stable `crossplane/crossplane` tag supplied by the parent. Omit a docs-only capability when stable release inclusion cannot be established.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but code, schemas, tests, examples, or corroborated stable documentation must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/agents/okf-crossplane-runtime-update-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-runtime-update-researcher/AGENT.md
@@ -1,0 +1,25 @@
+# Crossplane Runtime Stable-Update Researcher
+
+Research relevant new provider- and controller-development capabilities between two stable releases of `crossplane/crossplane-runtime`.
+
+## Domain scope
+
+Focus on new exported or supported developer surfaces:
+
+- public Go packages, interfaces, builders, controller helpers, managed-resource helpers, connection details, conditions, logging, metrics, events, reconciliation, and testing utilities
+- behavior changes that create a new supported implementation pattern for Crossplane providers or controllers
+- stable examples and tests that establish how the new capability is used
+
+Ignore internal refactors that do not add a public capability. Do not report dependency bumps, performance-only changes, security fixes, or correctness-only bug fixes.
+
+When a candidate depends on a Crossplane Core capability, state that dependency but do not expand research beyond the minimum stable corroboration required.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but code, schemas, tests, examples, or corroborated stable documentation must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/agents/okf-function-go-templating-update-researcher/AGENT.md
+++ b/.agents/agents/okf-function-go-templating-update-researcher/AGENT.md
@@ -1,0 +1,28 @@
+# function-go-templating Stable-Update Researcher
+
+Research relevant new user-facing capabilities between two stable releases of `crossplane-contrib/function-go-templating`.
+
+## Domain scope
+
+Focus on:
+
+- input CRD or schema additions
+- template source and rendering behavior
+- newly exposed template or helper functions
+- context, extra resources, readiness, connection details, credentials, composed-resource behavior, and package installation
+- new or materially expanded stable examples
+- exact dependency changes only when they expose a new user-facing template capability
+
+Use the selected stable release's `go.mod` and function map when a candidate involves Sprig or another function library. Do not report a dependency's functions unless the selected release actually exposes them.
+
+Exclude legacy v1 Claim examples, security fixes, ordinary bug fixes, dependency-only updates, CI, and release automation.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but code, schemas, tests, examples, or corroborated stable documentation must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/agents/okf-function-sequencer-update-researcher/AGENT.md
+++ b/.agents/agents/okf-function-sequencer-update-researcher/AGENT.md
@@ -1,0 +1,27 @@
+# function-sequencer Stable-Update Researcher
+
+Research relevant new user-facing capabilities between two stable releases of `crossplane-contrib/function-sequencer`.
+
+## Domain scope
+
+Focus on:
+
+- input API or schema additions
+- new sequencing, dependency, readiness, selection, or ordering behavior
+- newly supported composition-function workflows
+- examples, package metadata, implementation, and tests that establish the capability
+- stable feature promotions
+
+Exclude changes that only repair incorrect sequencing, panics, races, documentation wording, CI, dependencies, or release automation.
+
+Keep all conclusions specific to `function-sequencer`. Do not generalize its behavior to Crossplane Core or other functions.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but code, schemas, tests, examples, or corroborated stable documentation must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/skills/okf-updates/SKILL.md
+++ b/.agents/skills/okf-updates/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: okf-updates
+description: Explicit-only workflow that detects newer stable releases for selected Crossplane ecosystem sources, delegates release-diff research only for changed component identities, and presents an evidence-backed feature shortlist before any OKF content is changed.
+disable-model-invocation: true
+metadata:
+  version: "1.0"
+  license: Apache-2.0
+---
+
+# Crossplane OKF update discovery workflow
+
+Run this workflow only after the user explicitly invokes `$okf-updates`, `/skill:okf-updates`, or `/okf-updates`.
+
+This workflow is a read-only discovery and selection stage. It does not edit the catalog, source locks, claim ledger, indexes, logs, agent definitions, branches, or GitHub state.
+
+The root or parent agent owns component identity resolution, delegation decisions, aggregation, and the handoff to the normal `$okf` workflow. Update researchers are read-only and never delegate further.
+
+## Components
+
+Check exactly these configured components unless the requester narrows the scope:
+
+| Component ID | Repository | Current identity in `.okf/sources.lock.yaml` | Latest stable identity | Researcher |
+| --- | --- | --- | --- | --- |
+| `crossplane-core` | `crossplane/crossplane` | `sources.crossplane.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-crossplane-core-update-researcher` |
+| `crossplane-runtime` | `crossplane/crossplane-runtime` | `sources.crossplane-runtime.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-crossplane-runtime-update-researcher` |
+| `function-sequencer` | `crossplane-contrib/function-sequencer` | `sources.function-sequencer.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-function-sequencer-update-researcher` |
+| `function-go-templating` | `crossplane-contrib/function-go-templating` | `sources.function-go-templating.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-function-go-templating-update-researcher` |
+| `crossplane-docs` | `crossplane/docs` | `sources.crossplane-docs.series` and `commit` | documentation series matching the latest stable Crossplane major.minor plus the newest commit touching `content/v<major>.<minor>/**` | `okf-crossplane-docs-update-researcher` |
+
+Do not infer a component identity from catalog frontmatter, prose, a moving branch, or an agent's memory. The source lock is the only definition of the current identity.
+
+## Stable identity rules
+
+For repositories that publish semantic-version tags:
+
+1. Enumerate tags or releases without starting a subagent.
+2. Parse semantic versions numerically.
+3. Accept only a complete stable version such as `v2.4.1` or `0.13.0`.
+4. Exclude draft releases and any tag with prerelease metadata, including alpha, beta, preview, milestone, release-candidate, snapshot, or development suffixes.
+5. Resolve the selected tag to its full commit SHA.
+6. Do not fall back to `main`, `master`, a release branch, or a prerelease.
+7. A changed commit behind the same stable tag is not a new version. Report it as an integrity conflict and do not delegate until the conflict is understood.
+
+For `crossplane/docs`:
+
+1. Resolve the latest stable Crossplane tag first.
+2. Derive `v<major>.<minor>` from that tag.
+3. Find the newest commit on the docs default branch that changes files under `content/v<major>.<minor>/**`.
+4. The docs identity is the pair `(series, path commit)`.
+5. Ignore default-branch commits that do not touch the selected stable series.
+6. Documentation changes may describe unreleased behavior. The docs researcher must corroborate every candidate against the latest stable Crossplane release before reporting it as available.
+
+## Identity decision gate
+
+Resolve every requested component before starting any update researcher.
+
+Use these states:
+
+- `CURRENT`: the locked and latest stable identities are equal. Do not start the component researcher.
+- `UPDATE_AVAILABLE`: the latest stable identity is newer than the locked identity. Start the component researcher.
+- `UNTRACKED`: the component has no lock entry. Treat the latest stable identity as an update candidate and use the immediately preceding stable tag as the bounded comparison baseline when one exists.
+- `BLOCKED`: stable identity resolution failed, the lock is malformed, the locked tag cannot be resolved, history is not comparable, or a tag-to-commit integrity conflict exists. Do not start the component researcher.
+
+Never start a researcher for `CURRENT` or `BLOCKED`.
+
+For `UNTRACKED`, do not scan the full repository history. Compare only the immediately preceding stable tag to the latest stable tag. If there is no previous stable tag, inspect the latest stable release notes and the smallest high-signal source set.
+
+## Delegation
+
+Run at most three direct researchers at once. Use a second batch when more than three components changed.
+
+Give each researcher:
+
+- component ID and repository
+- locked identity or `UNTRACKED`
+- latest stable identity
+- exact comparison base and head tags or commits
+- release dates when available
+- the stable identity rules above
+- the feature relevance rules below
+- the required output contract
+
+Researchers must use only the assigned repository and comparison range, except where their canonical role explicitly requires stable Crossplane corroboration.
+
+## Relevant feature rules
+
+Report a candidate only when the stable comparison adds a user-facing capability that could improve this OKF bundle, such as:
+
+- a new public API, resource, field, command, interface, helper, template function, input option, or supported workflow
+- a new composition, reconciliation, readiness, dependency, rendering, provider-development, or documentation capability
+- a previously prerelease capability that becomes available in a stable release
+- a new official stable-series guide that explains a released capability not already represented in the catalog
+
+A deprecation or removal is not a feature candidate unless it is inseparable from a replacement capability that should be documented.
+
+Exclude:
+
+- security fixes and vulnerability remediation
+- bug fixes, regressions, race fixes, panic fixes, and correctness-only patches
+- dependency bumps, generated-file churn, refactoring, test-only work, CI, release automation, build changes, formatting, and typo fixes
+- performance changes without a new user-visible capability
+- prerelease-only, unreleased, proposed, open-PR, or issue-only behavior
+- legacy Crossplane v1 Claims, claim workflows, deprecated XRD v1 semantics, and documentation under `content/v1.*`
+
+Do not turn release-note wording into fact without checking code, schemas, tests, examples, or stable documentation in the assigned comparison.
+
+## Researcher output contract
+
+Each researcher returns one compact packet:
+
+```yaml
+component: <component-id>
+repository: <owner/name>
+from_identity:
+  version_or_series: <value-or-UNTRACKED>
+  commit: <full-sha-or-null>
+to_identity:
+  version_or_series: <stable-value>
+  commit: <full-sha>
+comparison:
+  base: <tag-or-sha>
+  head: <tag-or-sha>
+candidates:
+  - title: <short feature title>
+    category: <api|workflow|function|sdk|documentation|feature-promotion>
+    summary: <what became newly available>
+    stable_availability: <release or corroborated docs series>
+    okf_fit: <which catalog area or concept would benefit>
+    evidence:
+      - <immutable commit-pinned file URL with line range, release, or compare reference>
+    confidence: <direct|corroborated>
+excluded:
+  - <short grouped reason, not one line per commit>
+uncertainties:
+  - <bounded unresolved question>
+```
+
+Return `candidates: []` when the new stable version contains no relevant feature. Do not pad the result with bug fixes or housekeeping.
+
+## Aggregate result
+
+The parent agent:
+
+1. Presents the identity state of every checked component.
+2. Merges only candidate features from researchers that ran.
+3. Deduplicates features documented by both Core and docs without losing either evidence role.
+4. Assigns deterministic selection IDs in the form `<component-id>@<stable-identity>:F<two-digits>`.
+5. Shows the title, concise summary, OKF fit, stable release, and primary evidence for every candidate.
+6. States which changed components had no relevant feature.
+7. Does not edit source locks or catalog files during discovery.
+
+Ask the requester to select candidate IDs. Do not select features on the requester's behalf.
+
+## Selected-feature handoff
+
+A requester reply that selects one or more candidate IDs from this explicitly invoked workflow is explicit permission to run the normal OKF update logic for those candidates. No second `$okf` command is required.
+
+Process each selected candidate independently:
+
+1. Preserve the candidate ID, exact stable identity, comparison evidence, and bounded feature scope.
+2. Load and follow `.agents/skills/okf/SKILL.md`.
+3. Treat one candidate as one `$okf` request. Do not combine multiple selected features into one research/write batch.
+4. Create the dedicated branch required by the normal workflow for that single feature.
+5. Use the normal domain researchers for semantic research. The update researcher packet is discovery evidence, not sufficient catalog evidence by itself.
+6. Update the source lock only in the feature branch when required by the normal workflow.
+7. Run deterministic validation, `okf-reviewer`, and `mise run lint`.
+8. Commit, push, and open one pull request for that feature.
+9. Never include unselected candidates implicitly.
+
+When `function-sequencer` is selected, the normal `$okf` workflow must first create its dedicated semantic researcher and bounded source profile if they still do not exist, because every composition function requires its own normal researcher set.
+
+## Completion report
+
+For discovery, report:
+
+- locked and latest stable identities
+- which researchers ran and which were skipped
+- candidate IDs and supporting stable evidence
+- changed components with no relevant features
+- blocked identity checks and why they were blocked
+- confirmation that discovery made no catalog or lock changes
+
+For selected-feature processing, use the completion report required by the normal `$okf` workflow for each feature.

--- a/.agents/skills/okf-updates/agents/openai.yaml
+++ b/.agents/skills/okf-updates/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Crossplane OKF Updates"
+  short_description: "Find relevant features in newer stable source releases"
+  default_prompt: "Use $okf-updates to compare locked Crossplane ecosystem sources with their latest stable identities and present relevant feature candidates."
+policy:
+  allow_implicit_invocation: false

--- a/.codex/agents/okf-crossplane-core-update-researcher.toml
+++ b/.codex/agents/okf-crossplane-core-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-crossplane-core-update-researcher"
+description = "Read-only researcher for relevant new Crossplane v2 Core capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-crossplane-core-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-crossplane-docs-update-researcher.toml
+++ b/.codex/agents/okf-crossplane-docs-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-crossplane-docs-update-researcher"
+description = "Read-only researcher for newly documented capabilities in a stable Crossplane documentation series."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-crossplane-docs-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-crossplane-runtime-update-researcher.toml
+++ b/.codex/agents/okf-crossplane-runtime-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-crossplane-runtime-update-researcher"
+description = "Read-only researcher for relevant new crossplane-runtime developer capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-crossplane-runtime-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-function-go-templating-update-researcher.toml
+++ b/.codex/agents/okf-function-go-templating-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-go-templating-update-researcher"
+description = "Read-only researcher for relevant new function-go-templating capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-go-templating-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-function-sequencer-update-researcher.toml
+++ b/.codex/agents/okf-function-sequencer-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-sequencer-update-researcher"
+description = "Read-only researcher for relevant new function-sequencer capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-sequencer-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.pi/agents/okf-crossplane-core-update-researcher.md
+++ b/.pi/agents/okf-crossplane-core-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-crossplane-core-update-researcher
+description: Read-only researcher for relevant new Crossplane v2 Core capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-crossplane-core-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-crossplane-docs-update-researcher.md
+++ b/.pi/agents/okf-crossplane-docs-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-crossplane-docs-update-researcher
+description: Read-only researcher for newly documented capabilities in a stable Crossplane documentation series.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-crossplane-docs-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-crossplane-runtime-update-researcher.md
+++ b/.pi/agents/okf-crossplane-runtime-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-crossplane-runtime-update-researcher
+description: Read-only researcher for relevant new crossplane-runtime developer capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-crossplane-runtime-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-function-go-templating-update-researcher.md
+++ b/.pi/agents/okf-function-go-templating-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-go-templating-update-researcher
+description: Read-only researcher for relevant new function-go-templating capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-go-templating-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-function-sequencer-update-researcher.md
+++ b/.pi/agents/okf-function-sequencer-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-sequencer-update-researcher
+description: Read-only researcher for relevant new function-sequencer capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-sequencer-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/prompts/okf-updates.md
+++ b/.pi/prompts/okf-updates.md
@@ -1,0 +1,12 @@
+---
+description: Find relevant OKF feature candidates in newer stable Crossplane ecosystem releases
+argument-hint: <optional component scope>
+---
+
+Load and follow `.agents/skills/okf-updates/SKILL.md` for this request.
+
+This command is explicit permission to run the read-only OKF update-discovery workflow for the scope below:
+
+$ARGUMENTS
+
+Follow `AGENTS.md`. Resolve every component identity before delegation, start only the matching `*-update-researcher` agents for changed identities, and keep all discovery read-only. After presenting candidate IDs, a requester selection is permission to hand each selected feature to the normal `.agents/skills/okf/SKILL.md` workflow independently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 ## Default behavior
 
 - Do not start the OKF generation or enrichment workflow automatically.
-- Run the workflow only when the user explicitly invokes `$okf`, `/skill:okf`, or `/okf`.
-- Keep this file limited to repository-wide rules. The shared workflow lives in `.agents/skills/okf/`.
+- Run the normal workflow only when the user explicitly invokes `$okf`, `/skill:okf`, or `/okf`, or selects a feature candidate returned by an explicitly invoked `$okf-updates`, `/skill:okf-updates`, or `/okf-updates` workflow.
+- Run update discovery only when the user explicitly invokes `$okf-updates`, `/skill:okf-updates`, or `/okf-updates`.
+- Keep this file limited to repository-wide rules. The shared workflows live in `.agents/skills/okf/` and `.agents/skills/okf-updates/`.
 - Canonical specialist instructions live in `.agents/agents/<name>/AGENT.md`.
 - Runtime adapters in `.codex/agents/` and `.pi/agents/` contain only runtime metadata and a reference to the matching canonical instruction file. Do not duplicate role instructions in runtime adapters.
 
@@ -16,6 +17,7 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Subagents are read-only researchers. They return compact evidence packets and never edit the catalog.
 - Use at most three direct subagents at once. Do not create nested subagent trees.
 - When running in Pi, use only the project agents whose names start with `okf-`. Their tool allowlists intentionally omit editing tools and nested delegation.
+- The `$okf-updates` parent resolves locked and latest stable component identities before delegation. It must not start an update researcher when no newer stable identity exists.
 
 ## Change workflow
 
@@ -27,6 +29,8 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - After reviewer approval and a successful lint run, commit every intended change. Do not leave generated or supporting files uncommitted.
 - Create commits with a Developer Certificate of Origin sign-off by default by using `git commit --signoff` (or `git commit -s`). Omit the sign-off only when the user explicitly requests an unsigned commit.
 - Push the branch and open a pull request for the reviewed commit set. Do not merge the pull request unless the user explicitly requests it.
+- `$okf-updates` discovery is read-only. It must not update source locks or catalog files before the requester selects a candidate.
+- After selection from `$okf-updates`, process each selected feature independently through the normal `$okf` workflow. Never include an unselected feature implicitly.
 
 ## Domain routing
 
@@ -36,6 +40,7 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use `okf-function-go-templating-researcher` for user-facing `function-go-templating` installation, input schema, examples, and additional template functions.
 - Use `okf-function-go-templating-sprig-researcher` for the exact Sprig version exposed by the selected stable `function-go-templating` release.
 - Use `okf-function-go-templating-project-history-researcher` for human-authored issues and pull requests related to that function.
+- Use the matching `*-update-researcher` only from the explicit `$okf-updates` workflow and only after its component identity changes.
 - Every composition function must have its own canonical instruction files and matching Codex and Pi adapters before its OKF concepts are generated.
 - Use the generic `okf-crossplane-researcher` only for domains without a dedicated agent, such as CLI, runtime, SDKs, tools, native providers, and testing tools.
 - The Crossplane CLI is a separate catalog domain and is not part of Crossplane Core.


### PR DESCRIPTION
## What changed

- add an explicit-only `$okf-updates` workflow
- resolve current component identities from `.okf/sources.lock.yaml` before delegation
- compare only stable releases and skip subagents for unchanged or blocked identities
- define a stable-series identity for `crossplane/docs`
- add dedicated update researchers for:
  - `crossplane/crossplane`
  - `crossplane/crossplane-runtime`
  - `crossplane-contrib/function-sequencer`
  - `crossplane-contrib/function-go-templating`
  - `crossplane/docs`
- add matching Codex and Pi adapters
- aggregate only relevant new features and exclude security fixes, small bugs, dependency churn, CI, and prerelease behavior
- treat requester-selected candidate IDs as permission to run the normal `$okf` workflow once per feature
- keep discovery read-only; source locks and catalog content change only in selected-feature branches

## Design notes

The parent resolves all component identities before starting researchers. Components are classified as `CURRENT`, `UPDATE_AVAILABLE`, `UNTRACKED`, or `BLOCKED`. Researchers run only for `UPDATE_AVAILABLE` and `UNTRACKED` components, with at most three direct researchers active at once.

`crossplane/docs` does not publish stable release tags. Its identity is the stable Crossplane documentation series plus the newest commit touching that series. Documentation candidates must be corroborated against the latest stable Crossplane release.

`function-sequencer` is currently untracked in `.okf/sources.lock.yaml`. The workflow therefore compares its immediately preceding stable tag with its latest stable tag instead of scanning its complete history.

## Validation

- parsed the new YAML metadata and Markdown frontmatter
- parsed every new Codex TOML adapter
- verified every runtime adapter references an existing canonical `AGENT.md`
- compared the branch with `main`: 19 intended files, no catalog or source-lock changes
- all commits include a DCO sign-off
- GitHub Actions `mise run lint`: passed
- GitHub Actions super-linter: pending