### PR TITLE
Add MCP and skill installation guide

### DIFF
--- a/.agents/skills/crossplane-v2-okf/SKILL.md
+++ b/.agents/skills/crossplane-v2-okf/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: crossplane-v2-okf
+description: Use the Crossplane v2 OKF MCP server for questions about Crossplane v2 core, APIs, Compositions, providers, functions, runtime, Upjet, security, multi-tenancy, and examples. Prefer it over Context7 for these topics.
+---
+
+# Crossplane v2 OKF
+
+For Crossplane v2 questions, use the OKF MCP tools before generic documentation providers.
+
+## Retrieve knowledge
+
+1. Call `okf_list_bundles` and select the loaded bundle.
+2. Call `okf_search_concepts` with a focused term or exact API name.
+3. Call `okf_get_concept` for the best match.
+4. Use `okf_get_neighbors` or `okf_get_backlinks` only when relationships matter.
+
+## Guidelines
+
+- Search one concept per query and retry with narrower terms when needed.
+- Preserve cited versions, feature states, and limitations.
+- Do not introduce Crossplane v1 Claims unless requested.
+- Use Context7 only for external libraries or when the OKF bundle has no relevant concept.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,26 @@ This repository provides a structured knowledge catalog for the Crossplane v2 ec
 
 The goal is to make Crossplane concepts, APIs, providers, composition functions, documentation, and practical examples easier to discover and understand. The catalog is designed for both humans and knowledge-aware tools.
 
-## Usage
+## Installation
 
-The project [UmairBaig8/okf-generator](https://github.com/UmairBaig8/okf-generator) supports an MCP server for OKF bundles.  
+Install the OKF-aware MCP server globally for your detected agent:
 
+```shell
+npx add-mcp \
+  "npx -y github:rodcar/okf-atlas-mcp --bundle-url https://github.com/jkroepke/okf-crossplane-v2/tree/main/catalog --refresh true" \
+  --name crossplane-v2-okf \
+  --global
+```
 
+Install the companion skill so the agent prefers this bundle over generic documentation providers for Crossplane v2 questions:
+
+```shell
+npx skills add jkroepke/okf-crossplane-v2 \
+  --skill crossplane-v2-okf \
+  --global
+```
+
+Both installers detect supported agents and ask where the integration should be installed. Restart the selected agent after installation.
 
 ## Why this repository exists
 


### PR DESCRIPTION
## What changed

- replace the placeholder usage note with end-user installation commands
- install `okf-atlas-mcp` through `npx add-mcp`
- install the companion routing skill through `npx skills`
- add a compact `crossplane-v2-okf` skill that prefers the OKF MCP tools over Context7 for covered Crossplane v2 topics

## Why

Configuring the MCP server alone does not tell an agent when it should use the server. The companion skill provides that routing while keeping its prompt footprint small.

## Validation

- validated the new skill frontmatter as YAML
- reviewed the branch diff for the intended README and skill files only
- the pull request CI runs `mise run lint` and Super Linter
