### PR TITLE
Document temporary public MCP availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The goal is to make Crossplane concepts, APIs, providers, composition functions,
 
 ## Installation
 
+> [!WARNING]
+> The public MCP server is a temporary early-access service for early adopters. Its availability is not guaranteed, and it may change or be removed without notice. It is intended to bridge the current tooling gap until the OKF ecosystem provides practical, end-user-friendly solutions that run locally. For reliable or production use, self-host the included container.
+
 Install the hosted OKF-aware MCP server globally for your detected agent:
 
 ```shell


### PR DESCRIPTION
## What changed

- add a prominent warning above the hosted MCP installation command
- clarify that the public endpoint is a temporary early-access service for early adopters
- state that availability is not guaranteed and the endpoint may change or be removed
- point reliable and production users to the included self-hosting option

## Why

The hosted MCP endpoint currently bridges a tooling gap in the young OKF ecosystem. Users should not interpret it as a permanent hosted service. The warning sets the correct expectation until practical, end-user-friendly local OKF MCP solutions are broadly available.

## Validation

- reviewed the rendered GitHub admonition syntax
- confirmed the branch changes only `README.md`
- commit includes the required DCO sign-off
