### PR TITLE
docs: add ESO PushSecret external store pattern

### DIFF
--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -263,6 +263,20 @@ supporting_sources:
     repository: hashicorp/terraform-provider-azurerm
     kind: terraform-provider
     documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
+  - id: external-secrets
+    repository: external-secrets/external-secrets
+    kind: kubernetes-secrets-operator
+    authority: supporting
+    release_policy: user-requested-stable-tag
+    paths:
+      - docs/api/pushsecret.md
+      - docs/guides/pushsecrets.md
+      - docs/snippets/vault-pushsecret.yaml
+      - docs/snippets/aws-sm-push-secret-with-metadata.yaml
+      - apis/externalsecrets/v1alpha1/pushsecret_types.go
+      - config/crds/bases/external-secrets.io_pushsecrets.yaml
+      - LICENSE
+    usage: platform secret-publication pattern; not evidence of Crossplane behavior
 
 project_history_sources:
   - id: argo-cd-project-history

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -5,6 +5,25 @@ title: Crossplane catalog claim ledger
 
 # Scope
 
+## External Secrets Operator PushSecret pattern
+
+Selected supporting source: External Secrets Operator `v2.7.0` at
+`e215053f3e68504de7483f9542b49f19f98293a1`. This is a community
+Kubernetes-secret publication pattern, not a Crossplane API or recommendation.
+No Crossplane Core release or documentation series is used. The served
+`external-secrets.io/v1alpha1` PushSecret API makes the pattern Alpha. Claims,
+deprecated XRD v1, legacy v1 XR semantics, and copied source material are
+excluded. The source license is Apache-2.0; the catalog example is authored
+from the API shape and is not copied or adapted.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| core/pushsecret-external-store-pattern | ESO's namespaced PushSecret selects a Kubernetes Secret and pushes mapped or bulk-selected data to external secret providers through SecretStore or ClusterSecretStore references. | API and documented-guidance | supporting | corroborated | Alpha from served `external-secrets.io/v1alpha1`; [CRD](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/config/crds/bases/external-secrets.io_pushsecrets.yaml#L8-L36), [API guide](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/api/pushsecret.md#L3-L8), [types](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L90-L121) |
+| core/pushsecret-external-store-pattern | A Secret selected by name must be in the same namespace as PushSecret; PushSecret can reference SecretStore or ClusterSecretStore targets. | API | supporting | direct | Alpha from served `v1alpha1`; [source-Secret rule](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L124-L149), [store reference type](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L37-L55) |
+| core/pushsecret-external-store-pattern | `data` maps source keys to remote keys, while `dataTo` bulk-selects keys; a dataTo target must name or label-select a store, and its key conversion defaults to None. | API | supporting | direct | Alpha from served `v1alpha1`; [data mapping](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L172-L193), [dataTo validation and conversion](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L215-L256) |
+| core/pushsecret-external-store-pattern | Replace is the default update policy; IfNotExists avoids overwrite but may leave the cluster and provider values different. Provider secrets are retained on PushSecret deletion unless deletionPolicy is Delete. | documented-guidance | supporting | direct | Alpha from served `v1alpha1`; [policy guide](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/guides/pushsecrets.md#L2-L6) |
+| core/pushsecret-external-store-pattern | Official v2.7.0 snippets demonstrate a Vault SecretStore with remote-key mappings and AWS Secrets Manager-oriented per-entry metadata. | illustrative-pattern | supporting | direct | Alpha from served `v1alpha1`; [Vault snippet](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/snippets/vault-pushsecret.yaml#L10-L32), [AWS snippet](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/snippets/aws-sm-push-secret-with-metadata.yaml#L1-L29) |
+
 ## Historical design: controlled rollout of Composition Functions
 
 Selected Core release and requested design snapshot `v2.3.3` at `09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d`. Its status is `Accepted`; it contains no prominent accuracy or implementation-completeness warning. That status establishes only that the proposal was accepted, not that it was released or remains current. Claims, deprecated XRD v1, legacy v1 XR semantics, and CLI material are excluded.

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -209,3 +209,9 @@ sources:
     commit: e708470d529a10ac1a3f02ab6fdd339b65958372
     selected_by: function-go-templating/go.mod
     resolved_at: 2026-07-12
+  external-secrets:
+    repository: external-secrets/external-secrets
+    tag: v2.7.0
+    commit: e215053f3e68504de7483f9542b49f19f98293a1
+    selected_by: user-requested PushSecret pattern
+    resolved_at: 2026-07-16

--- a/catalog/core/index.md
+++ b/catalog/core/index.md
@@ -19,6 +19,7 @@
 * [Namespaced composition boundaries](namespaced-composition-boundaries.md) - Same-namespace enforcement and the open issue #6759 report.
 * [Cross-namespace synchronization patterns](cross-namespace-synchronization-patterns.md) - Evidence-backed provider-kubernetes and community-controller tradeoffs.
 * [Composition health in GitOps tools](composition-gitops-health.md) - Native status limitations and the documented Argo CD and Flux customization boundaries.
+* [Push platform-team Secrets to external stores](pushsecret-external-store-pattern.md) - An Alpha External Secrets Operator pattern for publishing selected Kubernetes Secret data to configured external stores.
 
 # Environment and migration
 

--- a/catalog/core/pushsecret-external-store-pattern.md
+++ b/catalog/core/pushsecret-external-store-pattern.md
@@ -1,0 +1,114 @@
+---
+type: pattern
+title: Push platform-team Secrets to external stores
+description: An Alpha External Secrets Operator pattern for pushing selected Kubernetes Secret data to configured external secret stores.
+resource: https://external-secrets.io/latest/api/pushsecret/
+tags: [crossplane, platform, secrets, external-secrets-operator, pushsecret]
+timestamp: 2026-07-16T00:00:00Z
+source_repository: external-secrets/external-secrets
+source_tag: v2.7.0
+source_commit: e215053f3e68504de7483f9542b49f19f98293a1
+source_role: supporting
+feature_state: Alpha
+---
+
+# Overview
+
+Platform teams can use External Secrets Operator (ESO) `PushSecret` to publish
+selected data from a Kubernetes `Secret` to an external secret provider through
+a configured `SecretStore` or `ClusterSecretStore`. This is an ESO pattern, not
+a Crossplane feature or recommendation.[1][2]
+
+`PushSecret` is namespaced and served as `external-secrets.io/v1alpha1`, so this
+pattern is Alpha. A source `Secret` selected by name must be in the same
+namespace as the `PushSecret`.[1][3]
+
+# Pattern
+
+1. Configure the target provider and authentication as an ESO `SecretStore` or
+   `ClusterSecretStore`. Its provider-specific authentication, authorization,
+   and metadata are outside this pattern.
+2. Let the team own the source Kubernetes `Secret` and a same-namespace
+   `PushSecret`.
+3. Use `data` for explicit source-key to remote-key mappings. Use `dataTo` only
+   when bulk selection and key rewriting are needed; every `dataTo` entry must
+   identify a target store by name or label selector.[2][4]
+4. Choose lifecycle behavior deliberately. `Replace` is the default and
+   overwrites an existing provider value. `IfNotExists` avoids overwrite, but
+   can leave the cluster and provider values different. Provider data remains
+   after deleting `PushSecret` unless `deletionPolicy: Delete` is set.[5]
+
+This authored starter manifest maps two keys to a Vault-configured
+`SecretStore`; it is not copied from the ESO source.
+
+```yaml
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: team-service-credentials
+  namespace: team-a
+spec:
+  secretStoreRefs:
+    - name: team-a-vault
+      kind: SecretStore
+  selector:
+    secret:
+      name: service-credentials
+  data:
+    - match:
+        secretKey: username
+        remoteRef:
+          remoteKey: teams/team-a/service
+          property: username
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: teams/team-a/service
+          property: password
+```
+
+# Provider examples
+
+ESO's v2.7.0 documentation includes a Vault `SecretStore` example with
+per-key remote mappings. Its AWS Secrets Manager-oriented example shows that
+`data` entries can carry provider-specific metadata such as a KMS key,
+format, description, and tags.[6][7] Those fields must be evaluated against
+the selected provider's ESO documentation and access policy.
+
+# Limitations
+
+- Use ESO's exact names: `SecretStore` and `ClusterSecretStore`, rather than
+  the imprecise phrase “Cloud Provider SecretsStore”.
+- This pattern makes the selected Kubernetes Secret data available to the
+  chosen external provider. Scope ESO and provider credentials, store access,
+  and team RBAC accordingly.
+- `dataTo` applies conversion before matching and rewriting, defaults to
+  `None`, and its metadata is provider-specific.[4][8]
+- ESO is a supporting source here. It does not establish Crossplane API
+  behavior, compatibility, or security guarantees.
+
+# Relationships
+
+The source Secret can be a normal composed Kubernetes Secret, such as the
+connection-details aggregate described in
+[Compose connection details with function-go-templating](../functions/function-go-templating/connection-details.md).
+That Crossplane pattern determines how the Secret is composed; ESO determines
+whether and how selected data is later published to an external store.
+
+# Citations
+
+[1] [PushSecret CRD scope, served API version, and purpose](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/config/crds/bases/external-secrets.io_pushsecrets.yaml#L8-L36)
+
+[2] [PushSecret documented selection, per-key, bulk, and templating capabilities](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/api/pushsecret.md#L3-L8)
+
+[3] [Same-namespace source Secret and selector types](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L124-L149)
+
+[4] [Explicit mappings, bulk-store validation, and key conversion](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/apis/externalsecrets/v1alpha1/pushsecret_types.go#L172-L256)
+
+[5] [Update and deletion policy guidance](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/guides/pushsecrets.md#L2-L6)
+
+[6] [Vault PushSecret example](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/snippets/vault-pushsecret.yaml#L10-L32)
+
+[7] [AWS Secrets Manager-oriented metadata example](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/snippets/aws-sm-push-secret-with-metadata.yaml#L1-L29)
+
+[8] [Bulk PushSecret `dataTo` documentation](https://github.com/external-secrets/external-secrets/blob/e215053f3e68504de7483f9542b49f19f98293a1/docs/api/pushsecret.md#L30-L84)

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,6 +1,7 @@
 # Catalog Update Log
 
 ## 2026-07-16
+* **Creation**: Added an Alpha External Secrets Operator PushSecret pattern for publishing selected platform-team Kubernetes Secret data to configured external secret stores, including Vault and AWS examples.
 * **Update**: Extended provider-family guidance with Upbound's pinned official-provider installation, monolith ownership, shared-family dependency, and offline-resolution boundaries.
 * **Creation**: Added provider CRD schema discovery guidance for version-addressed Upbound API routes, pinned source-tree fallbacks, and AWS package-identity boundaries.
 * **Creation**: Added Crossplane CLI local Composition rendering guidance, including Docker runtime requirements, Functions-only input handling, and observed-resource status fixtures.


### PR DESCRIPTION
## Summary
- document an Alpha External Secrets Operator PushSecret pattern for platform-team secrets
- pin ESO v2.7.0 and record supporting-source evidence, claims, and licensing boundary
- link the pattern from the Core catalog index

## Validation
- mise run lint