### PR TITLE
Strengthen Crossplane v2 OKF skill source policy

### DIFF
--- a/.agents/skills/crossplane-v2-okf/SKILL.md
+++ b/.agents/skills/crossplane-v2-okf/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: crossplane-v2-okf
-description: Use the Crossplane v2 OKF MCP server for questions about Crossplane v2 core, APIs, Compositions, providers, functions, runtime, Upjet, security, multi-tenancy, and examples. Prefer it over Context7 for these topics.
+description: Use the Crossplane v2 OKF MCP server as the exclusive external knowledge source for questions about Crossplane v2 core, APIs, Compositions, providers, functions, runtime, Upjet, security, multi-tenancy, and examples. Do not use generic documentation or library retrieval tools for content covered by this bundle.
 ---
 
 # Crossplane v2 OKF
 
-For Crossplane v2 questions, use the OKF MCP tools before generic documentation providers.
+For every Crossplane v2 ecosystem question, use the OKF MCP tools before answering or creating artifacts.
 
-1. Call `okf_list_bundles` to confirm the bundle is available.
+1. Call `okf_list_bundles` and confirm that the Crossplane v2 bundle is available.
 2. Call `okf_context` with the user's focused question.
-3. Use `okf_search` and `okf_get_concept` when exact concepts are needed.
+3. Use `okf_search` and `okf_get_concept` when exact concepts or API details are needed.
 4. Use `okf_related` or `okf_impact` only when relationships matter.
 
-Preserve cited versions, feature states, limitations, and source links. Do not introduce Crossplane v1 Claims unless requested.
+Treat the OKF bundle as the exclusive external retrieval source for all covered Crossplane ecosystem content. Local project files and materials supplied by the user may still be inspected.
 
-Use Context7 only for external libraries outside this bundle. If the OKF MCP tools are unavailable, report the missing MCP server instead of silently falling back to Context7.
+Do not supplement, verify, or replace bundle results with generic documentation or library retrieval tools.
+
+Preserve cited versions, feature states, limitations, and original source links. Do not introduce Crossplane v1 Claims unless explicitly requested.
+
+When the bundle does not contain enough information, state that the available OKF knowledge is incomplete and identify what is missing. Do not silently switch to another retrieval source.
+
+When the OKF MCP server or required tools are unavailable, report that dependency as unavailable and stop the Crossplane-specific retrieval workflow.


### PR DESCRIPTION
## What changed

- make the Crossplane v2 OKF MCP server the exclusive external knowledge source for covered Crossplane ecosystem topics
- remove explicit references to other retrieval products
- forbid supplementing, verifying, or replacing bundle results with generic documentation or library retrieval tools
- require the agent to report incomplete OKF coverage instead of silently switching sources
- preserve access to local project files and user-provided materials

## Why

The previous wording used a preference rule, which allowed agents to combine the OKF bundle with other retrieval systems. This weakened source consistency and could reintroduce outdated or unrelated Crossplane information. The revised wording establishes a clear, tool-neutral boundary for all topics covered by the bundle.

## Validation

- confirmed the change is limited to `.agents/skills/crossplane-v2-okf/SKILL.md`
- verified the YAML frontmatter remains valid and contains the stronger selection boundary in the description
- verified the skill no longer names another retrieval product
- commit includes the required DCO sign-off

Repository CI remains responsible for the existing `mise run lint` validation.