### PR TITLE
feat(mcp): add provider CRD discovery tools

### DIFF
--- a/.agents/skills/crossplane-v2-okf/SKILL.md
+++ b/.agents/skills/crossplane-v2-okf/SKILL.md
@@ -7,6 +7,8 @@ description: Use the Crossplane v2 OKF MCP server as the exclusive external know
 
 For every Crossplane v2 ecosystem question, use the OKF MCP tools before answering or creating artifacts.
 
+## General workflow
+
 1. Call `okf_list_bundles` and confirm that the Crossplane v2 bundle is available.
 2. Call `okf_context` with the user's focused question.
 3. When the task is to build, author, design, or substantially review a
@@ -18,18 +20,96 @@ For every Crossplane v2 ecosystem question, use the OKF MCP tools before answeri
 5. Use `okf_related` or `okf_impact` only when relationships matter.
 
 The Composition developer starter is a navigation route, not a substitute for
-provider-specific evidence. Retrieve separately selected and pinned provider
-concepts for concrete resource schemas, credentials, condition semantics,
-connection details, and ProviderConfig behavior. If the target provider or
-release is missing, identify it as required project input instead of assuming a
-universal Crossplane shape.
+provider-specific evidence. Use the provider workflow below for concrete
+managed-resource schemas, examples, and upstream Terraform documentation.
 
-Treat the OKF bundle as the exclusive external retrieval source for all covered Crossplane ecosystem content. Local project files and materials supplied by the user may still be inspected.
+## Package versions
 
-Do not supplement, verify, or replace bundle results with generic documentation or library retrieval tools.
+Use `get_versions(name)` before selecting a provider or function release when
+an exact version was not supplied by the user or the local project.
 
-Preserve cited versions, feature states, limitations, and original source links. Do not introduce Crossplane v1 Claims unless explicitly requested.
+- Pass a short package name, an `account/package` name, or a full
+  `xpkg.upbound.io` package reference.
+- Prefer `latest`, which is the highest stable semantic version returned by the
+  tool. Do not replace it with the latest prerelease.
+- Preserve the resolved package name and selected version in all later tool
+  calls and in the answer.
+- When the user or local project pins a version, use that exact version and do
+  not silently upgrade it.
 
-When the bundle does not contain enough information, state that the available OKF knowledge is incomplete and identify what is missing. Do not silently switch to another retrieval source.
+## Provider CRD workflow
 
-When the OKF MCP server or required tools are unavailable, report that dependency as unavailable and stop the Crossplane-specific retrieval workflow. Do not fall back to web search, `curl`, raw GitHub URLs, `gh`, Context7, or another documentation source to retrieve Crossplane material. Local project files and user-supplied material remain in scope.
+For provider-specific resource questions, use the following sequence. All
+provider CRD tools use the argument order shown here.
+
+1. Discover candidates with
+   `provider_crd_search(provider_name, provider_version, crd_search_term)`.
+   Use a focused kind, API-group, or wildcard term. Do not assume a resource
+   from name similarity.
+2. Select an exact result and retrieve its schema with
+   `provider_crd_get_definition(provider_name, provider_version, crd_name)`.
+3. When creating or reviewing manifests, retrieve example locations with
+   `provider_crd_get_examples(provider_name, provider_version, crd_name)`.
+4. For an Upjet-managed resource, retrieve the mapped Terraform documentation
+   location with
+   `provider_crd_get_terraform_docs(provider_name, provider_version, crd_name)`
+   when field semantics, constraints, import behavior, or upstream examples are
+   relevant.
+
+`crd_name` may be a kind, `group/Kind`, `group/version/Kind`, or a YAML fragment
+containing `apiVersion` and `kind`. Prefer `group/version/Kind` after discovery
+because it keeps the API surface explicit and avoids ambiguous kinds.
+
+Keep the same resolved provider name and provider version across search,
+definition, examples, and Terraform documentation calls. Never combine a CRD
+definition from one provider release with examples or Terraform documentation
+resolved from another release.
+
+## Fetching returned source locations
+
+`provider_crd_get_examples` and `provider_crd_get_terraform_docs` may return
+only a GitHub `repository`, immutable or versioned `ref`, and `path`. A connected
+GitHub integration may fetch those exact returned locations.
+
+This is a narrow source-following exception, not permission for independent
+GitHub research:
+
+- Fetch only the repository, ref, and path returned by the MCP tool.
+- Do not broaden the search to adjacent files, branches, issues, pull requests,
+  or repository-wide code search unless the user explicitly requests source
+  investigation beyond the MCP result.
+- Do not replace the returned ref with `main`, `master`, or another version.
+- Treat a missing returned file as incomplete provider evidence and report it.
+- Preserve the returned location in the final answer so the evidence remains
+  traceable.
+
+The Terraform documentation tool establishes the Crossplane-to-Terraform
+resource mapping from provider source. Do not infer Terraform resource names by
+converting the CRD kind or API group yourself.
+
+## Evidence boundaries
+
+Treat the OKF bundle and the provider tools exposed by the same MCP server as
+the exclusive external retrieval sources for covered Crossplane ecosystem
+content. Local project files and materials supplied by the user may still be
+inspected.
+
+Do not supplement, verify, or replace bundle results with generic documentation
+or library retrieval tools. The only external source fetch allowed by this
+skill is an exact GitHub location returned by
+`provider_crd_get_examples` or `provider_crd_get_terraform_docs`.
+
+Preserve cited versions, feature states, limitations, CRD API versions, and
+original source locations. Do not introduce Crossplane v1 Claims unless
+explicitly requested.
+
+When the bundle or provider tools do not contain enough information, state that
+the available OKF knowledge is incomplete and identify what is missing. Do not
+silently switch to another retrieval source or guess a provider schema,
+example path, or Terraform mapping.
+
+When the OKF MCP server or required tools are unavailable, report that
+dependency as unavailable and stop the Crossplane-specific retrieval workflow.
+Do not fall back to web search, `curl`, arbitrary raw GitHub URLs, `gh`,
+Context7, or another documentation source to retrieve Crossplane material.
+Local project files and user-supplied material remain in scope.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app
 
 COPY mcp/server.py /app/server.py
 COPY mcp/crossplane_marketplace.py /app/crossplane_marketplace.py
+COPY mcp/provider_crd_tools.py /app/provider_crd_tools.py
 COPY mcp/entrypoint.sh /app/entrypoint.sh
 
 RUN chmod 0755 /app/entrypoint.sh \
@@ -45,6 +46,7 @@ ENV BUNDLE_URL="https://github.com/jkroepke/okf-crossplane-v2.git" \
     MCP_ALLOWED_HOSTS="crossplane.mcp.jkroepke.de,crossplane.mcp.jkroepke.de:*,127.0.0.1:*,localhost:*" \
     MCP_ALLOWED_ORIGINS="https://crossplane.mcp.jkroepke.de,http://127.0.0.1:*,http://localhost:*" \
     UPBOUND_API_URL="https://api.upbound.io" \
+    GITHUB_RAW_URL="https://raw.githubusercontent.com" \
     UPBOUND_API_TIMEOUT="15" \
     PYTHONUNBUFFERED="1" \
     UV_NO_PROGRESS="1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN groupadd --gid 65532 okf \
 WORKDIR /app
 
 COPY mcp/server.py /app/server.py
+COPY mcp/crossplane_marketplace.py /app/crossplane_marketplace.py
 COPY mcp/entrypoint.sh /app/entrypoint.sh
 
 RUN chmod 0755 /app/entrypoint.sh \
@@ -43,6 +44,8 @@ ENV BUNDLE_URL="https://github.com/jkroepke/okf-crossplane-v2.git" \
     MCP_STATELESS_HTTP="true" \
     MCP_ALLOWED_HOSTS="crossplane.mcp.jkroepke.de,crossplane.mcp.jkroepke.de:*,127.0.0.1:*,localhost:*" \
     MCP_ALLOWED_ORIGINS="https://crossplane.mcp.jkroepke.de,http://127.0.0.1:*,http://localhost:*" \
+    UPBOUND_API_URL="https://api.upbound.io" \
+    UPBOUND_API_TIMEOUT="15" \
     PYTHONUNBUFFERED="1" \
     UV_NO_PROGRESS="1"
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ The catalog is refreshed at container startup. If fetching or ingestion fails an
 
 The MCP tools are read-only, but the public endpoint has no application-level authentication. Apply request limits and access controls at the reverse proxy when required.
 
+### Crossplane package tools
+
+The server adds three tools backed by the public Upbound Marketplace API:
+
+- `get_versions(name)` resolves a provider or function package and returns its latest stable version, latest published version, and available versions.
+- `search_resources(provider, pattern="*", version="latest", limit=100)` searches the CRDs in a provider with case-insensitive shell-style wildcards. Patterns are matched against the API group, kind, `group/kind`, and `Kind.group`.
+- `get_definitions(provider, resource, version="latest")` returns the CRD definition for a kind or qualified `group/Kind` resource.
+
+Package names can be short names such as `provider-aws` and `function-go-templating`, qualified names such as `crossplane-contrib/provider-aws`, or full `xpkg.upbound.io` references. Short-name resolution prefers packages published by `crossplane-contrib`, then `crossplane`, then `upbound`. Use a qualified name to select another publisher explicitly.
+
+The default `latest` value selects the highest stable semantic version. Set an explicit version to inspect another published package version. Self-hosted deployments need outbound HTTPS access to the configured `UPBOUND_API_URL`, which defaults to `https://api.upbound.io`.
+
 ## Why this repository exists
 
 Crossplane knowledge is distributed across many repositories and kinds of sources:

--- a/README.md
+++ b/README.md
@@ -51,15 +51,19 @@ The MCP tools are read-only, but the public endpoint has no application-level au
 
 ### Crossplane package tools
 
-The server adds three tools backed by the public Upbound Marketplace API:
+The server adds these tools backed by the public Upbound Marketplace API and provider source repositories:
 
 - `get_versions(name)` resolves a provider or function package and returns its latest stable version, latest published version, and available versions.
-- `provider_crd_search(provider, pattern="*", version="latest", limit=100)` searches the CRDs in a provider with case-insensitive shell-style wildcards. Patterns are matched against the API group, kind, `group/kind`, and `Kind.group`.
-- `provider_crd_get(provider, resource, version="latest")` returns the CRD definition for a kind or qualified `group/Kind` resource.
+- `provider_crd_search(provider_name, provider_version, crd_search_term)` searches CRDs in one explicit provider package version. The search term supports case-insensitive shell-style wildcards.
+- `provider_crd_get_definition(provider_name, provider_version, crd_name)` returns the complete CRD definition.
+- `provider_crd_get_examples(provider_name, provider_version, crd_name)` returns GitHub repository paths for generated and handwritten examples. Without an API version, it selects the latest served CRD API version, for example `examples-generated/namespaced/ec2/v1beta2/route.yaml`.
+- `provider_crd_get_terraform_docs(provider_name, provider_version, crd_name)` returns the Terraform provider repository, version, and documentation path. It reads the Crossplane provider Makefile and the generated controller mapping instead of inferring the Terraform resource name.
 
-Package names can be short names such as `provider-aws` and `function-go-templating`, qualified names such as `crossplane-contrib/provider-aws`, or full `xpkg.upbound.io` references. Short-name resolution prefers packages published by `crossplane-contrib`, then `crossplane`, then `upbound`. Use a qualified name to select another publisher explicitly.
+`crd_name` accepts a Kind, `group/Kind`, `group/version/Kind`, or a YAML fragment containing `apiVersion` and `kind`.
 
-The default `latest` value selects the highest stable semantic version. Set an explicit version to inspect another published package version. Self-hosted deployments need outbound HTTPS access to the configured `UPBOUND_API_URL`, which defaults to `https://api.upbound.io`.
+Package names can be qualified names such as `upbound/provider-aws`, aliases such as `crossplane-contrib/provider-upjet-aws`, or full `xpkg.upbound.io` references. Use a qualified provider package name when multiple packages share the same short name.
+
+The CRD tools require an explicit provider version. The value `latest` is also supported and selects the highest stable semantic version. Self-hosted deployments need outbound HTTPS access to `UPBOUND_API_URL` and `GITHUB_RAW_URL`.
 
 ## Why this repository exists
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The MCP tools are read-only, but the public endpoint has no application-level au
 The server adds three tools backed by the public Upbound Marketplace API:
 
 - `get_versions(name)` resolves a provider or function package and returns its latest stable version, latest published version, and available versions.
-- `search_resources(provider, pattern="*", version="latest", limit=100)` searches the CRDs in a provider with case-insensitive shell-style wildcards. Patterns are matched against the API group, kind, `group/kind`, and `Kind.group`.
-- `get_definitions(provider, resource, version="latest")` returns the CRD definition for a kind or qualified `group/Kind` resource.
+- `provider_crd_search(provider, pattern="*", version="latest", limit=100)` searches the CRDs in a provider with case-insensitive shell-style wildcards. Patterns are matched against the API group, kind, `group/kind`, and `Kind.group`.
+- `provider_crd_get(provider, resource, version="latest")` returns the CRD definition for a kind or qualified `group/Kind` resource.
 
 Package names can be short names such as `provider-aws` and `function-go-templating`, qualified names such as `crossplane-contrib/provider-aws`, or full `xpkg.upbound.io` references. Short-name resolution prefers packages published by `crossplane-contrib`, then `crossplane`, then `upbound`. Use a qualified name to select another publisher explicitly.
 

--- a/mcp/crossplane_marketplace.py
+++ b/mcp/crossplane_marketplace.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+class MarketplaceError(RuntimeError):
+    """Raised when the Upbound Marketplace API cannot satisfy a request."""
+
+
+@dataclass(frozen=True)
+class PackageReference:
+    account: str
+    repository: str
+    package_type: str
+
+    @property
+    def name(self) -> str:
+        return f"{self.account}/{self.repository}"
+
+
+_SEMVER = re.compile(
+    r"^v?(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?$"
+)
+_ACCOUNT_PRIORITY = {
+    "crossplane-contrib": 0,
+    "crossplane": 1,
+    "upbound": 2,
+}
+
+
+class MarketplaceClient:
+    def __init__(
+        self,
+        base_url: str = "https://api.upbound.io",
+        timeout: float = 15.0,
+        opener: Callable[..., Any] = urlopen,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._opener = opener
+
+    def get_versions(self, name: str) -> dict[str, Any]:
+        package = self.resolve_package(name)
+        metadata = self._request_json(
+            f"/v1/packageMetadata/{self._segment(package.account)}/{self._segment(package.repository)}"
+        )
+        versions = self._versions(metadata)
+        stable_versions = [version for version in versions if self._semver_key(version) is not None]
+        stable_versions.sort(key=self._semver_key, reverse=True)
+
+        latest_published = self._string(metadata.get("latestVersion")) or self._string(
+            metadata.get("version")
+        )
+        latest_stable = stable_versions[0] if stable_versions else latest_published
+
+        return {
+            "package": package.name,
+            "type": package.package_type,
+            "latest": latest_stable,
+            "latest_published": latest_published,
+            "stable_versions": stable_versions,
+            "versions": versions,
+        }
+
+    def search_resources(
+        self,
+        provider: str,
+        pattern: str = "*",
+        version: str = "latest",
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        if limit < 1 or limit > 500:
+            raise ValueError("limit must be between 1 and 500")
+
+        package = self.resolve_package(provider, expected_type="provider")
+        selected_version = self._select_version(package, version)
+        payload = self._request_json(
+            f"/v1/packages/{self._segment(package.account)}/"
+            f"{self._segment(package.repository)}/{self._segment(selected_version)}/resources"
+        )
+        resources = payload.get("customResourceDefinitions", [])
+        if not isinstance(resources, list):
+            raise MarketplaceError("Marketplace response does not contain a CRD list")
+
+        normalized_pattern = pattern.strip() or "*"
+        matches = [
+            self._normalize_resource(resource)
+            for resource in resources
+            if isinstance(resource, dict)
+            and self._resource_matches(resource, normalized_pattern)
+        ]
+        matches.sort(key=lambda item: (item["group"].lower(), item["kind"].lower()))
+        truncated = len(matches) > limit
+
+        return {
+            "provider": package.name,
+            "version": selected_version,
+            "pattern": normalized_pattern,
+            "count": len(matches),
+            "truncated": truncated,
+            "resources": matches[:limit],
+        }
+
+    def get_definitions(
+        self,
+        provider: str,
+        resource: str,
+        version: str = "latest",
+    ) -> dict[str, Any]:
+        package = self.resolve_package(provider, expected_type="provider")
+        selected_version = self._select_version(package, version)
+        match = self._resolve_resource(package, selected_version, resource)
+        definition = self._request_document(
+            f"/v1/packages/{self._segment(package.account)}/"
+            f"{self._segment(package.repository)}/{self._segment(selected_version)}/resources/"
+            f"{self._segment(match['group'])}/{self._segment(match['kind'])}"
+        )
+        return {
+            "provider": package.name,
+            "version": selected_version,
+            "resource": match,
+            "definition": definition,
+        }
+
+    def resolve_package(
+        self,
+        name: str,
+        expected_type: str | None = None,
+    ) -> PackageReference:
+        normalized = self._normalize_package_name(name)
+        if "/" in normalized:
+            account, repository = normalized.split("/", 1)
+            return PackageReference(
+                account=account,
+                repository=repository,
+                package_type=expected_type or self._package_type_from_name(repository),
+            )
+
+        package_type = expected_type or self._package_type_from_name(normalized)
+        query: dict[str, str | int] = {
+            "query": normalized,
+            "size": 100,
+            "page": 0,
+            "public": "true",
+        }
+        if package_type != "unknown":
+            query["packageType"] = package_type
+
+        payload = self._request_json("/v1/search", query)
+        packages = payload.get("packages", [])
+        if not isinstance(packages, list):
+            raise MarketplaceError("Marketplace search response does not contain packages")
+
+        candidates: list[PackageReference] = []
+        for candidate in packages:
+            if not isinstance(candidate, dict):
+                continue
+            account = self._string(candidate.get("account"))
+            repository = self._string(candidate.get("repository")) or self._string(
+                candidate.get("name")
+            )
+            candidate_type = self._string(candidate.get("type")) or self._string(
+                candidate.get("packageType")
+            )
+            if not account or not repository:
+                continue
+            if expected_type and candidate_type and candidate_type != expected_type:
+                continue
+            if normalized.lower() not in {
+                repository.lower(),
+                self._string(candidate.get("name")).lower(),
+                f"{account}/{repository}".lower(),
+            }:
+                continue
+            candidates.append(
+                PackageReference(
+                    account=account,
+                    repository=repository,
+                    package_type=candidate_type or package_type,
+                )
+            )
+
+        if not candidates:
+            raise MarketplaceError(f"No public Crossplane package found for {name!r}")
+
+        candidates.sort(
+            key=lambda item: (
+                _ACCOUNT_PRIORITY.get(item.account, 100),
+                item.account,
+                item.repository,
+            )
+        )
+        return candidates[0]
+
+    def _resolve_resource(
+        self,
+        package: PackageReference,
+        version: str,
+        resource: str,
+    ) -> dict[str, Any]:
+        payload = self._request_json(
+            f"/v1/packages/{self._segment(package.account)}/"
+            f"{self._segment(package.repository)}/{self._segment(version)}/resources"
+        )
+        resources = payload.get("customResourceDefinitions", [])
+        if not isinstance(resources, list):
+            raise MarketplaceError("Marketplace response does not contain a CRD list")
+
+        needle = resource.strip().lower()
+        matches = []
+        for item in resources:
+            if not isinstance(item, dict):
+                continue
+            normalized = self._normalize_resource(item)
+            identities = {
+                normalized["kind"].lower(),
+                f"{normalized['group']}/{normalized['kind']}".lower(),
+                f"{normalized['kind']}.{normalized['group']}".lower(),
+            }
+            if needle in identities:
+                matches.append(normalized)
+
+        if not matches:
+            raise MarketplaceError(
+                f"Resource {resource!r} was not found in {package.name}@{version}"
+            )
+        if len(matches) > 1:
+            choices = ", ".join(
+                f"{item['group']}/{item['kind']}" for item in matches[:10]
+            )
+            raise MarketplaceError(
+                f"Resource {resource!r} is ambiguous; use group/kind. Matches: {choices}"
+            )
+        return matches[0]
+
+    def _select_version(self, package: PackageReference, version: str) -> str:
+        requested = version.strip()
+        if requested and requested.lower() != "latest":
+            return requested
+        versions = self.get_versions(package.name)
+        selected = self._string(versions.get("latest"))
+        if not selected:
+            raise MarketplaceError(f"No stable version found for {package.name}")
+        return selected
+
+    def _request_json(
+        self,
+        path: str,
+        query: dict[str, str | int] | None = None,
+    ) -> dict[str, Any]:
+        body = self._request(path, query)
+        try:
+            payload = json.loads(body)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise MarketplaceError("Marketplace API returned invalid JSON") from error
+        if not isinstance(payload, dict):
+            raise MarketplaceError("Marketplace API returned an unexpected JSON value")
+        return payload
+
+    def _request_document(
+        self,
+        path: str,
+        query: dict[str, str | int] | None = None,
+    ) -> Any:
+        body = self._request(path, query)
+        try:
+            return json.loads(body)
+        except (TypeError, json.JSONDecodeError):
+            return body.decode("utf-8", errors="replace")
+
+    def _request(
+        self,
+        path: str,
+        query: dict[str, str | int] | None = None,
+    ) -> bytes:
+        url = f"{self.base_url}{path}"
+        if query:
+            url = f"{url}?{urlencode(query)}"
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json, application/yaml, text/yaml",
+                "User-Agent": "okf-crossplane-v2-mcp/1.0",
+            },
+        )
+        try:
+            response = self._opener(request, timeout=self.timeout)
+            with response:
+                return response.read()
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")[:500]
+            raise MarketplaceError(
+                f"Marketplace API returned HTTP {error.code}: {detail}"
+            ) from error
+        except URLError as error:
+            raise MarketplaceError(f"Marketplace API request failed: {error.reason}") from error
+        except TimeoutError as error:
+            raise MarketplaceError("Marketplace API request timed out") from error
+
+    @staticmethod
+    def _normalize_package_name(name: str) -> str:
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("name must not be empty")
+        if normalized.startswith("xpkg.upbound.io/"):
+            normalized = normalized.removeprefix("xpkg.upbound.io/")
+        if "@" in normalized:
+            normalized = normalized.split("@", 1)[0]
+        if ":" in normalized:
+            normalized = normalized.rsplit(":", 1)[0]
+        parts = normalized.split("/")
+        if len(parts) > 2 or any(not part for part in parts):
+            raise ValueError("name must be a package name or account/package reference")
+        return normalized
+
+    @staticmethod
+    def _package_type_from_name(name: str) -> str:
+        if name.startswith("provider-"):
+            return "provider"
+        if name.startswith("function-"):
+            return "function"
+        return "unknown"
+
+    @staticmethod
+    def _versions(metadata: dict[str, Any]) -> list[str]:
+        raw = metadata.get("versions", [])
+        if not isinstance(raw, list):
+            return []
+        return [str(version) for version in raw if isinstance(version, str)]
+
+    @staticmethod
+    def _semver_key(version: str) -> tuple[int, int, int] | None:
+        match = _SEMVER.fullmatch(version)
+        if match is None or match.group("prerelease") is not None:
+            return None
+        return (
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("patch")),
+        )
+
+    @staticmethod
+    def _normalize_resource(resource: dict[str, Any]) -> dict[str, Any]:
+        versions = resource.get("versions", [])
+        return {
+            "group": str(resource.get("group", "")),
+            "kind": str(resource.get("kind", "")),
+            "versions": versions if isinstance(versions, list) else [],
+            "storage_version": str(resource.get("storageVersion", "")),
+            "scope": str(resource.get("scope", "")),
+        }
+
+    @staticmethod
+    def _resource_matches(resource: dict[str, Any], pattern: str) -> bool:
+        group = str(resource.get("group", ""))
+        kind = str(resource.get("kind", ""))
+        normalized_pattern = pattern.lower()
+        candidates = (
+            group,
+            kind,
+            f"{group}/{kind}",
+            f"{kind}.{group}",
+        )
+        return any(
+            fnmatch.fnmatchcase(candidate.lower(), normalized_pattern)
+            for candidate in candidates
+        )
+
+    @staticmethod
+    def _segment(value: str) -> str:
+        return quote(value, safe="")
+
+    @staticmethod
+    def _string(value: Any) -> str:
+        return value if isinstance(value, str) else ""

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -193,7 +193,9 @@ class ProviderCRDTools:
             "terraform_resource_name": terraform_resource,
             "repository": terraform_repository,
             "ref": self._version_tag(terraform_version),
-            "path": f"{docs_path.rstrip('/')}/{docs_resource}.html.markdown",
+            "path": (
+                f"{docs_path.rstrip('/')}/{docs_resource}.html.markdown"
+            ),
         }
 
     def _resolve_resource(
@@ -203,8 +205,12 @@ class ProviderCRDTools:
         crd_name: str,
     ) -> tuple[str, str, dict[str, Any]]:
         group, api_version, kind = self._parse_crd_name(crd_name)
+        search_pattern = f"{group}/{kind}" if group else kind
         result = self.marketplace.search_resources(
-            self._provider_alias(provider_name), "*", provider_version, 500
+            self._provider_alias(provider_name),
+            search_pattern,
+            provider_version,
+            500,
         )
         resources = result.get("resources", [])
         if not isinstance(resources, list):

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+class ProviderToolError(RuntimeError):
+    """Raised when provider source data cannot satisfy a tool request."""
+
+
+class SourceFileNotFound(ProviderToolError):
+    """Raised when an expected source file does not exist."""
+
+
+class Marketplace(Protocol):
+    def search_resources(
+        self,
+        provider: str,
+        pattern: str = "*",
+        version: str = "latest",
+        limit: int = 100,
+    ) -> dict[str, Any]: ...
+
+    def get_definitions(
+        self,
+        provider: str,
+        resource: str,
+        version: str = "latest",
+    ) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class ProviderSource:
+    repository: str
+    ref: str
+
+
+_PROVIDER_ALIASES = {
+    "provider-upjet-aws": "upbound/provider-aws",
+    "crossplane-contrib/provider-upjet-aws": "upbound/provider-aws",
+    "provider-upjet-azure": "upbound/provider-azure",
+    "crossplane-contrib/provider-upjet-azure": "upbound/provider-azure",
+    "provider-upjet-gcp": "upbound/provider-gcp",
+    "crossplane-contrib/provider-upjet-gcp": "upbound/provider-gcp",
+}
+_UPJET_SOURCE_REPOSITORIES = {
+    "aws": "crossplane-contrib/provider-upjet-aws",
+    "azure": "crossplane-contrib/provider-upjet-azure",
+    "gcp": "crossplane-contrib/provider-upjet-gcp",
+}
+_KUBERNETES_API_VERSION = re.compile(
+    r"^v(?P<major>[1-9]\d*)(?:(?P<stage>alpha|beta)(?P<number>[1-9]\d*))?$"
+)
+_MAKE_ASSIGNMENT = r"^(?:export\s+)?{name}\s*(?::=|\?=|=)\s*(?P<value>[^#\n]+)"
+_MAX_CRD_RESULTS = 100
+
+
+class ProviderCRDTools:
+    def __init__(
+        self,
+        marketplace: Marketplace,
+        github_raw_url: str = "https://raw.githubusercontent.com",
+        timeout: float = 15.0,
+        opener: Callable[..., Any] = urlopen,
+    ) -> None:
+        self.marketplace = marketplace
+        self.github_raw_url = github_raw_url.rstrip("/")
+        self.timeout = timeout
+        self._opener = opener
+
+    def search(
+        self,
+        provider_name: str,
+        provider_version: str,
+        crd_search_term: str,
+    ) -> dict[str, Any]:
+        result = self.marketplace.search_resources(
+            self._provider_alias(provider_name),
+            crd_search_term.strip() or "*",
+            provider_version,
+            500,
+        )
+        crds = result.get("resources", [])
+        if not isinstance(crds, list):
+            raise ProviderToolError("Provider resource search returned an invalid CRD list")
+        return {
+            "provider_name": result.get("provider"),
+            "provider_version": result.get("version"),
+            "crd_search_term": result.get("pattern"),
+            "count": result.get("count", len(crds)),
+            "truncated": len(crds) > _MAX_CRD_RESULTS,
+            "crds": crds[:_MAX_CRD_RESULTS],
+        }
+
+    def get_definition(
+        self,
+        provider_name: str,
+        provider_version: str,
+        crd_name: str,
+    ) -> dict[str, Any]:
+        provider, version, resource = self._resolve_resource(
+            provider_name, provider_version, crd_name
+        )
+        result = self.marketplace.get_definitions(
+            provider, f"{resource['group']}/{resource['kind']}", version
+        )
+        return {
+            "provider_name": provider,
+            "provider_version": version,
+            "crd": resource,
+            "definition": result.get("definition"),
+        }
+
+    def get_examples(
+        self,
+        provider_name: str,
+        provider_version: str,
+        crd_name: str,
+    ) -> dict[str, Any]:
+        provider, version, resource = self._resolve_resource(
+            provider_name, provider_version, crd_name
+        )
+        source = self._provider_source(provider, version)
+        api_version = self._resource_api_version(resource)
+        service = self._resource_service(resource)
+        scope = self._resource_scope(resource)
+        filename = f"{self._kind_directory(resource['kind'])}.yaml"
+        candidates = [
+            (
+                True,
+                f"examples-generated/{scope}/{service}/{api_version}/{filename}",
+            ),
+            (
+                False,
+                f"examples/{service}/{scope}/{api_version}/{filename}",
+            ),
+        ]
+        examples = [
+            {
+                "repository": source.repository,
+                "ref": source.ref,
+                "path": path,
+                "generated": generated,
+            }
+            for generated, path in candidates
+            if self._github_file_exists(source.repository, source.ref, path)
+        ]
+        if not examples:
+            attempted = ", ".join(path for _, path in candidates)
+            raise ProviderToolError(
+                f"No examples found in {source.repository}@{source.ref}. "
+                f"Tried: {attempted}"
+            )
+        return {
+            "provider_name": provider,
+            "provider_version": version,
+            "crd": resource,
+            "examples": examples,
+        }
+
+    def get_terraform_docs(
+        self,
+        provider_name: str,
+        provider_version: str,
+        crd_name: str,
+    ) -> dict[str, Any]:
+        provider, version, resource = self._resolve_resource(
+            provider_name, provider_version, crd_name
+        )
+        source = self._provider_source(provider, version)
+        makefile = self._read_github_text(source.repository, source.ref, "Makefile")
+        terraform_repository = self._github_repository_from_url(
+            self._make_variable(makefile, "TERRAFORM_PROVIDER_REPO")
+        )
+        terraform_version = self._make_variable(
+            makefile, "TERRAFORM_PROVIDER_VERSION"
+        )
+        terraform_source = self._make_variable(
+            makefile, "TERRAFORM_PROVIDER_SOURCE"
+        )
+        docs_path = self._make_variable(makefile, "TERRAFORM_DOCS_PATH")
+        terraform_resource = self._terraform_resource_name(source, resource)
+        provider_prefix = terraform_source.rsplit("/", 1)[-1]
+        docs_resource = terraform_resource.removeprefix(f"{provider_prefix}_")
+        return {
+            "provider_name": provider,
+            "provider_version": version,
+            "crd": resource,
+            "terraform_resource_name": terraform_resource,
+            "repository": terraform_repository,
+            "ref": self._version_tag(terraform_version),
+            "path": f"{docs_path.rstrip('/')}/{docs_resource}.html.markdown",
+        }
+
+    def _resolve_resource(
+        self,
+        provider_name: str,
+        provider_version: str,
+        crd_name: str,
+    ) -> tuple[str, str, dict[str, Any]]:
+        group, api_version, kind = self._parse_crd_name(crd_name)
+        result = self.marketplace.search_resources(
+            self._provider_alias(provider_name), "*", provider_version, 500
+        )
+        resources = result.get("resources", [])
+        if not isinstance(resources, list):
+            raise ProviderToolError("Provider resource search returned an invalid CRD list")
+        matches = []
+        for resource in resources:
+            if not isinstance(resource, dict):
+                continue
+            if str(resource.get("kind", "")).lower() != kind.lower():
+                continue
+            if group and str(resource.get("group", "")).lower() != group.lower():
+                continue
+            versions = resource.get("versions", [])
+            if api_version and api_version not in versions:
+                continue
+            normalized = dict(resource)
+            if api_version:
+                normalized["requested_api_version"] = api_version
+            matches.append(normalized)
+        provider = str(result.get("provider", ""))
+        version = str(result.get("version", ""))
+        if not matches:
+            raise ProviderToolError(
+                f"CRD {crd_name!r} was not found in {provider}@{version}"
+            )
+        if len(matches) > 1:
+            choices = ", ".join(
+                f"{item.get('group')}/{item.get('kind')}" for item in matches[:10]
+            )
+            raise ProviderToolError(
+                f"CRD {crd_name!r} is ambiguous; use group/version/kind. "
+                f"Matches: {choices}"
+            )
+        return provider, version, matches[0]
+
+    def _terraform_resource_name(
+        self, source: ProviderSource, resource: dict[str, Any]
+    ) -> str:
+        controller_path = (
+            f"internal/controller/{self._resource_scope(resource)}/"
+            f"{self._resource_service(resource)}/"
+            f"{self._kind_directory(str(resource['kind']))}/zz_controller.go"
+        )
+        controller = self._read_github_text(
+            source.repository, source.ref, controller_path
+        )
+        matches = re.findall(r'o\.Provider\.Resources\["([^"]+)"\]', controller)
+        if not matches:
+            raise ProviderToolError(
+                f"Terraform mapping not found in {source.repository}@"
+                f"{source.ref}:{controller_path}"
+            )
+        if len(set(matches)) > 1:
+            raise ProviderToolError(
+                f"Multiple Terraform mappings found in {source.repository}@"
+                f"{source.ref}:{controller_path}"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _provider_alias(provider_name: str) -> str:
+        value = provider_name.strip()
+        return _PROVIDER_ALIASES.get(value, value)
+
+    @staticmethod
+    def _provider_source(provider: str, version: str) -> ProviderSource:
+        repository = provider
+        account, separator, package = provider.partition("/")
+        if separator and account == "upbound":
+            parts = package.split("-")
+            if len(parts) >= 2:
+                repository = _UPJET_SOURCE_REPOSITORIES.get(parts[1], repository)
+        return ProviderSource(repository=repository, ref=version)
+
+    @staticmethod
+    def _parse_crd_name(crd_name: str) -> tuple[str, str, str]:
+        value = crd_name.strip()
+        if not value:
+            raise ValueError("crd_name must not be empty")
+        api_version_match = re.search(r"(?m)^apiVersion:\s*(\S+)\s*$", value)
+        kind_match = re.search(r"(?m)^kind:\s*(\S+)\s*$", value)
+        if api_version_match and kind_match:
+            api_value = api_version_match.group(1)
+            if "/" not in api_value:
+                raise ValueError("apiVersion must contain a group and version")
+            group, api_version = api_value.rsplit("/", 1)
+            return group, api_version, kind_match.group(1)
+        parts = value.split("/")
+        if len(parts) == 1:
+            return "", "", parts[0]
+        if len(parts) == 2:
+            return parts[0], "", parts[1]
+        if len(parts) == 3:
+            return parts[0], parts[1], parts[2]
+        raise ValueError(
+            "crd_name must be kind, group/kind, group/version/kind, or YAML "
+            "with apiVersion and kind"
+        )
+
+    @classmethod
+    def _resource_api_version(cls, resource: dict[str, Any]) -> str:
+        requested = str(resource.get("requested_api_version", ""))
+        if requested:
+            return requested
+        versions = resource.get("versions", [])
+        if isinstance(versions, list) and versions:
+            values = [str(version) for version in versions]
+            return max(values, key=cls._kubernetes_api_version_key)
+        storage = str(resource.get("storage_version", ""))
+        if storage:
+            return storage
+        raise ProviderToolError("CRD does not expose an API version")
+
+    @staticmethod
+    def _kubernetes_api_version_key(version: str) -> tuple[int, int, int]:
+        match = _KUBERNETES_API_VERSION.fullmatch(version)
+        if match is None:
+            return (0, 0, 0)
+        stability = {None: 3, "beta": 2, "alpha": 1}[match.group("stage")]
+        return (
+            int(match.group("major")),
+            stability,
+            int(match.group("number") or 0),
+        )
+
+    @staticmethod
+    def _resource_service(resource: dict[str, Any]) -> str:
+        service = str(resource.get("group", "")).split(".", 1)[0]
+        if not service:
+            raise ProviderToolError("CRD group does not contain a provider service")
+        return service
+
+    @staticmethod
+    def _resource_scope(resource: dict[str, Any]) -> str:
+        return (
+            "namespaced"
+            if str(resource.get("scope", "")).lower() == "namespaced"
+            else "cluster"
+        )
+
+    @staticmethod
+    def _kind_directory(kind: str) -> str:
+        value = re.sub(r"[^0-9A-Za-z]", "", kind).lower()
+        if not value:
+            raise ProviderToolError("CRD kind cannot be converted to a source path")
+        return value
+
+    @staticmethod
+    def _make_variable(makefile: str, name: str) -> str:
+        pattern = re.compile(
+            _MAKE_ASSIGNMENT.format(name=re.escape(name)), re.MULTILINE
+        )
+        match = pattern.search(makefile)
+        if match is None:
+            raise ProviderToolError(f"{name} was not found in the provider Makefile")
+        value = match.group("value").strip().strip('"\'')
+        if not value or "$" in value:
+            raise ProviderToolError(
+                f"{name} is empty or requires Make variable expansion"
+            )
+        return value
+
+    @staticmethod
+    def _github_repository_from_url(url: str) -> str:
+        value = url.strip().removesuffix(".git").rstrip("/")
+        for prefix in (
+            "https://github.com/",
+            "http://github.com/",
+            "git@github.com:",
+        ):
+            if value.startswith(prefix):
+                repository = value.removeprefix(prefix)
+                if repository.count("/") == 1:
+                    return repository
+        raise ProviderToolError(f"Unsupported GitHub repository URL: {url}")
+
+    @staticmethod
+    def _version_tag(version: str) -> str:
+        return version if version.startswith("v") else f"v{version}"
+
+    def _read_github_file(self, repository: str, ref: str, path: str) -> bytes:
+        url = (
+            f"{self.github_raw_url}/{repository}/{quote(ref, safe='')}/"
+            f"{quote(path, safe='/')}"
+        )
+        request = Request(url, headers={"User-Agent": "okf-crossplane-v2-mcp/1.0"})
+        try:
+            response = self._opener(request, timeout=self.timeout)
+            with response:
+                return response.read()
+        except HTTPError as error:
+            if error.code == 404:
+                raise SourceFileNotFound(url) from error
+            detail = error.read().decode("utf-8", errors="replace")[:500]
+            raise ProviderToolError(
+                f"GitHub source returned HTTP {error.code}: {detail}"
+            ) from error
+        except URLError as error:
+            raise ProviderToolError(
+                f"GitHub source request failed: {error.reason}"
+            ) from error
+        except TimeoutError as error:
+            raise ProviderToolError("GitHub source request timed out") from error
+
+    def _read_github_text(self, repository: str, ref: str, path: str) -> str:
+        return self._read_github_file(repository, ref, path).decode(
+            "utf-8", errors="replace"
+        )
+
+    def _github_file_exists(self, repository: str, ref: str, path: str) -> bool:
+        try:
+            self._read_github_file(repository, ref, path)
+        except SourceFileNotFound:
+            return False
+        return True

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -68,7 +68,7 @@ def get_versions(name: str) -> dict[str, Any]:
 
 
 @mcp.tool()
-def search_resources(
+def provider_crd_search(
     provider: str,
     pattern: str = "*",
     version: str = "latest",
@@ -84,7 +84,7 @@ def search_resources(
 
 
 @mcp.tool()
-def get_definitions(
+def provider_crd_get(
     provider: str,
     resource: str,
     version: str = "latest",

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 from mcp.server.transport_security import TransportSecuritySettings
 from okf_mcp import server as upstream
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+
+from crossplane_marketplace import MarketplaceClient
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -27,6 +30,10 @@ def env_csv(name: str) -> list[str]:
 
 db_path = Path(os.environ.get("DB_PATH", "/data/catalog.duckdb")).resolve()
 bundle_name = os.environ.get("BUNDLE_NAME", "crossplane-v2-okf")
+marketplace = MarketplaceClient(
+    base_url=os.environ.get("UPBOUND_API_URL", "https://api.upbound.io"),
+    timeout=float(os.environ.get("UPBOUND_API_TIMEOUT", "15")),
+)
 
 if not db_path.is_file():
     raise RuntimeError(f"DuckDB catalog does not exist: {db_path}")
@@ -47,6 +54,48 @@ mcp.settings.transport_security = TransportSecuritySettings(
     allowed_hosts=allowed_hosts,
     allowed_origins=allowed_origins,
 )
+
+
+@mcp.tool()
+def get_versions(name: str) -> dict[str, Any]:
+    """Get the latest stable and available versions for a provider or function.
+
+    The name can be a short package name such as ``provider-aws`` or
+    ``function-go-templating``, an ``account/package`` reference, or a full
+    ``xpkg.upbound.io/account/package:version`` reference.
+    """
+    return marketplace.get_versions(name)
+
+
+@mcp.tool()
+def search_resources(
+    provider: str,
+    pattern: str = "*",
+    version: str = "latest",
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Search a provider's CRDs with a case-insensitive wildcard pattern.
+
+    The pattern is matched against the resource group, kind, ``group/kind``,
+    and ``Kind.group``. It supports shell-style wildcards such as ``*`` and
+    ``?``. The latest stable provider version is used by default.
+    """
+    return marketplace.search_resources(provider, pattern, version, limit)
+
+
+@mcp.tool()
+def get_definitions(
+    provider: str,
+    resource: str,
+    version: str = "latest",
+) -> dict[str, Any]:
+    """Get the CRD definition for one resource from a provider.
+
+    Resource accepts a kind such as ``Bucket`` or a qualified
+    ``group/Kind`` value such as ``s3.aws.upbound.io/Bucket``. Use the
+    qualified form when the kind exists in more than one API group.
+    """
+    return marketplace.get_definitions(provider, resource, version)
 
 
 @mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -84,7 +84,7 @@ def provider_crd_search(
     """Search CRDs in one explicit provider package version.
 
     The search term is a case-insensitive shell wildcard matched against the
-    group, kind, group/kind, Kind.group, and group/version/kind identities.
+    group, kind, group/kind, and Kind.group identities.
     """
     return provider_crds.search(provider_name, provider_version, crd_search_term)
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -10,6 +10,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from crossplane_marketplace import MarketplaceClient
+from provider_crd_tools import ProviderCRDTools
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -32,6 +33,13 @@ db_path = Path(os.environ.get("DB_PATH", "/data/catalog.duckdb")).resolve()
 bundle_name = os.environ.get("BUNDLE_NAME", "crossplane-v2-okf")
 marketplace = MarketplaceClient(
     base_url=os.environ.get("UPBOUND_API_URL", "https://api.upbound.io"),
+    timeout=float(os.environ.get("UPBOUND_API_TIMEOUT", "15")),
+)
+provider_crds = ProviderCRDTools(
+    marketplace,
+    github_raw_url=os.environ.get(
+        "GITHUB_RAW_URL", "https://raw.githubusercontent.com"
+    ),
     timeout=float(os.environ.get("UPBOUND_API_TIMEOUT", "15")),
 )
 
@@ -69,33 +77,60 @@ def get_versions(name: str) -> dict[str, Any]:
 
 @mcp.tool()
 def provider_crd_search(
-    provider: str,
-    pattern: str = "*",
-    version: str = "latest",
-    limit: int = 100,
+    provider_name: str,
+    provider_version: str,
+    crd_search_term: str,
 ) -> dict[str, Any]:
-    """Search a provider's CRDs with a case-insensitive wildcard pattern.
+    """Search CRDs in one explicit provider package version.
 
-    The pattern is matched against the resource group, kind, ``group/kind``,
-    and ``Kind.group``. It supports shell-style wildcards such as ``*`` and
-    ``?``. The latest stable provider version is used by default.
+    The search term is a case-insensitive shell wildcard matched against the
+    group, kind, group/kind, Kind.group, and group/version/kind identities.
     """
-    return marketplace.search_resources(provider, pattern, version, limit)
+    return provider_crds.search(provider_name, provider_version, crd_search_term)
 
 
 @mcp.tool()
-def provider_crd_get(
-    provider: str,
-    resource: str,
-    version: str = "latest",
+def provider_crd_get_definition(
+    provider_name: str,
+    provider_version: str,
+    crd_name: str,
 ) -> dict[str, Any]:
-    """Get the CRD definition for one resource from a provider.
+    """Get one provider CRD definition from an explicit package version.
 
-    Resource accepts a kind such as ``Bucket`` or a qualified
-    ``group/Kind`` value such as ``s3.aws.upbound.io/Bucket``. Use the
-    qualified form when the kind exists in more than one API group.
+    ``crd_name`` accepts Kind, group/Kind, group/version/Kind, or a YAML fragment
+    containing apiVersion and kind.
     """
-    return marketplace.get_definitions(provider, resource, version)
+    return provider_crds.get_definition(provider_name, provider_version, crd_name)
+
+
+@mcp.tool()
+def provider_crd_get_examples(
+    provider_name: str,
+    provider_version: str,
+    crd_name: str,
+) -> dict[str, Any]:
+    """Get GitHub repository paths for generated and handwritten CRD examples.
+
+    When no API version is included in ``crd_name``, the latest served CRD API
+    version is used for the example directory.
+    """
+    return provider_crds.get_examples(provider_name, provider_version, crd_name)
+
+
+@mcp.tool()
+def provider_crd_get_terraform_docs(
+    provider_name: str,
+    provider_version: str,
+    crd_name: str,
+) -> dict[str, Any]:
+    """Get the Terraform documentation repository and path for an Upjet CRD.
+
+    The provider Makefile selects the Terraform repository and version. The
+    generated controller identifies the exact Terraform resource name.
+    """
+    return provider_crds.get_terraform_docs(
+        provider_name, provider_version, crd_name
+    )
 
 
 @mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)

--- a/mcp/tests/test_crossplane_marketplace.py
+++ b/mcp/tests/test_crossplane_marketplace.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from crossplane_marketplace import MarketplaceClient, MarketplaceError
+
+
+class FakeMarketplaceClient(MarketplaceClient):
+    def __init__(self, responses: dict[str, dict[str, Any]]) -> None:
+        super().__init__()
+        self.responses = responses
+        self.requests: list[str] = []
+
+    def _response(self, path: str, query=None):
+        key = path
+        if query:
+            key = f"{path}?query={query.get('query', '')}"
+        self.requests.append(key)
+        try:
+            return self.responses[key]
+        except KeyError as error:
+            raise AssertionError(f"Unexpected request: {key}") from error
+
+    def _request_json(self, path: str, query=None):  # type: ignore[override]
+        return self._response(path, query)
+
+    def _request_document(self, path: str, query=None):  # type: ignore[override]
+        return self._response(path, query)
+
+
+SEARCH = {
+    "packages": [
+        {
+            "account": "upbound",
+            "repository": "provider-aws",
+            "name": "provider-aws",
+            "type": "provider",
+        },
+        {
+            "account": "crossplane-contrib",
+            "repository": "provider-aws",
+            "name": "provider-aws",
+            "type": "provider",
+        },
+    ]
+}
+RESOURCES = {
+    "customResourceDefinitions": [
+        {
+            "group": "s3.aws.upbound.io",
+            "kind": "Bucket",
+            "versions": ["v1beta1"],
+            "storageVersion": "v1beta1",
+            "scope": "Cluster",
+        },
+        {
+            "group": "iam.aws.upbound.io",
+            "kind": "Role",
+            "versions": ["v1beta1"],
+            "storageVersion": "v1beta1",
+            "scope": "Cluster",
+        },
+    ]
+}
+
+
+class MarketplaceClientTest(unittest.TestCase):
+    def test_resolve_package_prefers_crossplane_contrib(self) -> None:
+        client = FakeMarketplaceClient({"/v1/search?query=provider-aws": SEARCH})
+
+        package = client.resolve_package("provider-aws", expected_type="provider")
+
+        self.assertEqual(package.name, "crossplane-contrib/provider-aws")
+
+    def test_get_versions_returns_latest_stable(self) -> None:
+        client = FakeMarketplaceClient(
+            {
+                "/v1/packageMetadata/crossplane-contrib/provider-aws": {
+                    "latestVersion": "v2.0.0-rc.1",
+                    "versions": ["v1.2.0", "v2.0.0-rc.1", "v1.10.0"],
+                }
+            }
+        )
+
+        result = client.get_versions("crossplane-contrib/provider-aws")
+
+        self.assertEqual(result["latest"], "v1.10.0")
+        self.assertEqual(result["latest_published"], "v2.0.0-rc.1")
+
+    def test_search_resources_supports_wildcards(self) -> None:
+        client = FakeMarketplaceClient(
+            {
+                "/v1/packageMetadata/crossplane-contrib/provider-aws": {
+                    "latestVersion": "v1.10.0",
+                    "versions": ["v1.10.0"],
+                },
+                "/v1/packages/crossplane-contrib/provider-aws/v1.10.0/resources": RESOURCES,
+            }
+        )
+
+        result = client.search_resources(
+            "crossplane-contrib/provider-aws", "s3.*/*Bucket"
+        )
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["resources"][0]["kind"], "Bucket")
+
+    def test_get_definitions_resolves_group_and_kind(self) -> None:
+        definition = {
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+        }
+        client = FakeMarketplaceClient(
+            {
+                "/v1/packageMetadata/crossplane-contrib/provider-aws": {
+                    "latestVersion": "v1.10.0",
+                    "versions": ["v1.10.0"],
+                },
+                "/v1/packages/crossplane-contrib/provider-aws/v1.10.0/resources": RESOURCES,
+                "/v1/packages/crossplane-contrib/provider-aws/v1.10.0/resources/s3.aws.upbound.io/Bucket": definition,
+            }
+        )
+
+        result = client.get_definitions(
+            "crossplane-contrib/provider-aws", "s3.aws.upbound.io/Bucket"
+        )
+
+        self.assertEqual(result["definition"], definition)
+
+    def test_missing_resource_returns_clear_error(self) -> None:
+        client = FakeMarketplaceClient(
+            {
+                "/v1/packageMetadata/crossplane-contrib/provider-aws": {
+                    "latestVersion": "v1.10.0",
+                    "versions": ["v1.10.0"],
+                },
+                "/v1/packages/crossplane-contrib/provider-aws/v1.10.0/resources": RESOURCES,
+            }
+        )
+
+        with self.assertRaisesRegex(MarketplaceError, "was not found"):
+            client.get_definitions("crossplane-contrib/provider-aws", "Database")
+
+    def test_normalizes_oci_package_reference(self) -> None:
+        client = FakeMarketplaceClient({})
+
+        package = client.resolve_package(
+            "xpkg.upbound.io/crossplane-contrib/provider-aws:v1.10.0",
+            expected_type="provider",
+        )
+
+        self.assertEqual(package.name, "crossplane-contrib/provider-aws")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -48,11 +48,14 @@ class FakeMarketplace:
         limit: int = 100,
     ) -> dict[str, Any]:
         self.search_calls.append((provider, pattern, version, limit))
+        needle = pattern.lower().strip("*")
         matches = [
             resource
             for resource in RESOURCES
             if pattern == "*"
-            or pattern.lower().strip("*") in str(resource["kind"]).lower()
+            or needle in str(resource["kind"]).lower()
+            or needle
+            == f"{resource['group']}/{resource['kind']}".lower()
         ]
         return {
             "provider": provider,
@@ -121,6 +124,15 @@ class ProviderCRDToolsTest(unittest.TestCase):
             "apiVersion: apigatewayv2.aws.m.upbound.io/v1beta1\nkind: API",
         )
 
+        self.assertEqual(
+            marketplace.search_calls[0],
+            (
+                "upbound/provider-aws",
+                "apigatewayv2.aws.m.upbound.io/API",
+                "v2.3.0",
+                500,
+            ),
+        )
         self.assertEqual(
             marketplace.definition_calls[0],
             (

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from provider_crd_tools import ProviderCRDTools, ProviderToolError, SourceFileNotFound
+
+
+RESOURCES = [
+    {
+        "group": "apigatewayv2.aws.m.upbound.io",
+        "kind": "API",
+        "versions": ["v1beta1"],
+        "storage_version": "v1beta1",
+        "scope": "Namespaced",
+    },
+    {
+        "group": "apigatewayv2.aws.m.upbound.io",
+        "kind": "RouteResponse",
+        "versions": ["v1beta1"],
+        "storage_version": "v1beta1",
+        "scope": "Namespaced",
+    },
+    {
+        "group": "ec2.aws.m.upbound.io",
+        "kind": "Route",
+        "versions": ["v1beta1", "v1beta2"],
+        "storage_version": "v1beta1",
+        "scope": "Namespaced",
+    },
+]
+
+
+class FakeMarketplace:
+    def __init__(self) -> None:
+        self.search_calls: list[tuple[str, str, str, int]] = []
+        self.definition_calls: list[tuple[str, str, str]] = []
+
+    def search_resources(
+        self,
+        provider: str,
+        pattern: str = "*",
+        version: str = "latest",
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        self.search_calls.append((provider, pattern, version, limit))
+        matches = [
+            resource
+            for resource in RESOURCES
+            if pattern == "*"
+            or pattern.lower().strip("*") in str(resource["kind"]).lower()
+        ]
+        return {
+            "provider": provider,
+            "version": version,
+            "pattern": pattern,
+            "count": len(matches),
+            "resources": matches,
+        }
+
+    def get_definitions(
+        self,
+        provider: str,
+        resource: str,
+        version: str = "latest",
+    ) -> dict[str, Any]:
+        self.definition_calls.append((provider, resource, version))
+        return {
+            "definition": {
+                "apiVersion": "apiextensions.k8s.io/v1",
+                "kind": "CustomResourceDefinition",
+            }
+        }
+
+
+class FakeProviderCRDTools(ProviderCRDTools):
+    def __init__(
+        self,
+        marketplace: FakeMarketplace,
+        github_files: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(marketplace)
+        self.github_files = github_files or {}
+
+    def _read_github_file(  # type: ignore[override]
+        self, repository: str, ref: str, path: str
+    ) -> bytes:
+        key = f"{repository}@{ref}:{path}"
+        try:
+            return self.github_files[key].encode()
+        except KeyError as error:
+            raise SourceFileNotFound(key) from error
+
+
+class ProviderCRDToolsTest(unittest.TestCase):
+    def test_search_uses_requested_parameter_order(self) -> None:
+        marketplace = FakeMarketplace()
+        tools = FakeProviderCRDTools(marketplace)
+
+        result = tools.search(
+            "upbound/provider-aws", "v2.3.0", "*RouteResponse*"
+        )
+
+        self.assertEqual(
+            marketplace.search_calls[0],
+            ("upbound/provider-aws", "*RouteResponse*", "v2.3.0", 500),
+        )
+        self.assertEqual(result["crds"][0]["kind"], "RouteResponse")
+
+    def test_definition_accepts_api_version_and_kind_yaml(self) -> None:
+        marketplace = FakeMarketplace()
+        tools = FakeProviderCRDTools(marketplace)
+
+        result = tools.get_definition(
+            "upbound/provider-aws",
+            "v2.3.0",
+            "apiVersion: apigatewayv2.aws.m.upbound.io/v1beta1\nkind: API",
+        )
+
+        self.assertEqual(
+            marketplace.definition_calls[0],
+            (
+                "upbound/provider-aws",
+                "apigatewayv2.aws.m.upbound.io/API",
+                "v2.3.0",
+            ),
+        )
+        self.assertEqual(result["definition"]["kind"], "CustomResourceDefinition")
+
+    def test_examples_use_latest_served_api_version(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-upjet-aws@v2.3.0"
+        generated = "examples-generated/namespaced/ec2/v1beta2/route.yaml"
+        handwritten = "examples/ec2/namespaced/v1beta2/route.yaml"
+        tools = FakeProviderCRDTools(
+            marketplace,
+            {
+                f"{source}:{generated}": "generated",
+                f"{source}:{handwritten}": "handwritten",
+            },
+        )
+
+        result = tools.get_examples(
+            "upbound/provider-aws", "v2.3.0", "ec2.aws.m.upbound.io/Route"
+        )
+
+        self.assertEqual(result["examples"][0]["path"], generated)
+        self.assertTrue(result["examples"][0]["generated"])
+        self.assertEqual(result["examples"][1]["path"], handwritten)
+
+    def test_terraform_docs_use_makefile_and_generated_controller(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-upjet-aws@v2.3.0"
+        makefile = """
+export TERRAFORM_PROVIDER_VERSION := 6.53.0
+export TERRAFORM_PROVIDER_SOURCE := hashicorp/aws
+export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-aws
+export TERRAFORM_DOCS_PATH ?= website/docs/r
+"""
+        controller_path = (
+            "internal/controller/namespaced/apigatewayv2/routeresponse/"
+            "zz_controller.go"
+        )
+        tools = FakeProviderCRDTools(
+            marketplace,
+            {
+                f"{source}:Makefile": makefile,
+                f"{source}:{controller_path}": (
+                    'o.Provider.Resources["aws_apigatewayv2_route_response"]'
+                ),
+            },
+        )
+
+        result = tools.get_terraform_docs(
+            "upbound/provider-aws",
+            "v2.3.0",
+            "apigatewayv2.aws.m.upbound.io/v1beta1/RouteResponse",
+        )
+
+        self.assertEqual(result["repository"], "hashicorp/terraform-provider-aws")
+        self.assertEqual(result["ref"], "v6.53.0")
+        self.assertEqual(
+            result["path"],
+            "website/docs/r/apigatewayv2_route_response.html.markdown",
+        )
+        self.assertEqual(
+            result["terraform_resource_name"],
+            "aws_apigatewayv2_route_response",
+        )
+
+    def test_missing_crd_returns_clear_error(self) -> None:
+        tools = FakeProviderCRDTools(FakeMarketplace())
+
+        with self.assertRaisesRegex(ProviderToolError, "was not found"):
+            tools.get_definition("upbound/provider-aws", "v2.3.0", "Database")
+
+    def test_upjet_source_alias_resolves_to_package_name(self) -> None:
+        marketplace = FakeMarketplace()
+        tools = FakeProviderCRDTools(marketplace)
+
+        tools.search(
+            "crossplane-contrib/provider-upjet-aws", "v2.3.0", "API"
+        )
+
+        self.assertEqual(marketplace.search_calls[0][0], "upbound/provider-aws")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -161,36 +161,46 @@ export TERRAFORM_PROVIDER_SOURCE := hashicorp/aws
 export TERRAFORM_PROVIDER_REPO ?= https://github.com/hashicorp/terraform-provider-aws
 export TERRAFORM_DOCS_PATH ?= website/docs/r
 """
-        controller_path = (
-            "internal/controller/namespaced/apigatewayv2/routeresponse/"
-            "zz_controller.go"
-        )
-        tools = FakeProviderCRDTools(
-            marketplace,
-            {
-                f"{source}:Makefile": makefile,
-                f"{source}:{controller_path}": (
-                    'o.Provider.Resources["aws_apigatewayv2_route_response"]'
-                ),
-            },
-        )
+        github_files = {f"{source}:Makefile": makefile}
+        cases = [
+            (
+                "API",
+                "api",
+                "aws_apigatewayv2_api",
+                "website/docs/r/apigatewayv2_api.html.markdown",
+            ),
+            (
+                "RouteResponse",
+                "routeresponse",
+                "aws_apigatewayv2_route_response",
+                "website/docs/r/apigatewayv2_route_response.html.markdown",
+            ),
+        ]
+        for kind, directory, terraform_name, docs_path in cases:
+            controller_path = (
+                f"internal/controller/namespaced/apigatewayv2/{directory}/"
+                "zz_controller.go"
+            )
+            github_files[f"{source}:{controller_path}"] = (
+                f'o.Provider.Resources["{terraform_name}"]'
+            )
+        tools = FakeProviderCRDTools(marketplace, github_files)
 
-        result = tools.get_terraform_docs(
-            "upbound/provider-aws",
-            "v2.3.0",
-            "apigatewayv2.aws.m.upbound.io/v1beta1/RouteResponse",
-        )
-
-        self.assertEqual(result["repository"], "hashicorp/terraform-provider-aws")
-        self.assertEqual(result["ref"], "v6.53.0")
-        self.assertEqual(
-            result["path"],
-            "website/docs/r/apigatewayv2_route_response.html.markdown",
-        )
-        self.assertEqual(
-            result["terraform_resource_name"],
-            "aws_apigatewayv2_route_response",
-        )
+        for kind, _, terraform_name, docs_path in cases:
+            with self.subTest(kind=kind):
+                result = tools.get_terraform_docs(
+                    "upbound/provider-aws",
+                    "v2.3.0",
+                    f"apigatewayv2.aws.m.upbound.io/v1beta1/{kind}",
+                )
+                self.assertEqual(
+                    result["repository"], "hashicorp/terraform-provider-aws"
+                )
+                self.assertEqual(result["ref"], "v6.53.0")
+                self.assertEqual(result["path"], docs_path)
+                self.assertEqual(
+                    result["terraform_resource_name"], terraform_name
+                )
 
     def test_missing_crd_returns_clear_error(self) -> None:
         tools = FakeProviderCRDTools(FakeMarketplace())

--- a/mise.toml
+++ b/mise.toml
@@ -2,9 +2,13 @@
 "pipx:okf-ingest" = "latest"
 
 [tasks.lint]
-description = "Run OKF linter"
-depends = ['validate']
+description = "Run all checks"
+depends = ['validate', 'test']
 
 [tasks.validate]
 description = "Run OKF linter"
 run = "okf validate catalog/"
+
+[tasks.test]
+description = "Run MCP unit tests"
+run = "python -m unittest discover -s mcp/tests -v"


### PR DESCRIPTION
## What changed

- add `get_versions(name)` for provider and function package versions
- add `provider_crd_search(provider_name, provider_version, crd_search_term)` for wildcard CRD discovery
- add `provider_crd_get_definition(provider_name, provider_version, crd_name)` for complete CRD definitions
- add `provider_crd_get_examples(provider_name, provider_version, crd_name)` for generated and handwritten example locations
- add `provider_crd_get_terraform_docs(provider_name, provider_version, crd_name)` for Terraform documentation locations
- support Kind, `group/Kind`, `group/version/Kind`, and YAML `apiVersion` plus `kind` CRD identities
- resolve the latest served CRD API version for generated example paths
- read the provider Makefile for `TERRAFORM_PROVIDER_REPO`, `TERRAFORM_PROVIDER_VERSION`, `TERRAFORM_PROVIDER_SOURCE`, and `TERRAFORM_DOCS_PATH`
- read the generated Upjet controller to obtain the exact Terraform resource name instead of inferring it
- return GitHub repository, ref, and path references so agents can fetch the source with their own GitHub integration
- extend the `crossplane-v2-okf` skill with package-version and provider-CRD workflows
- allow GitHub retrieval only for exact repository, ref, and path locations returned by the MCP tools
- prevent mixing CRD definitions, examples, and Terraform documentation from different provider releases
- package the provider source helper in the container and document its outbound GitHub requirement

## Examples

- `examples-generated/namespaced/ec2/v*/route.yaml` resolves to the latest served API-version path
- `API` maps through its generated controller to `aws_apigatewayv2_api`
- `RouteResponse` maps through its generated controller to `aws_apigatewayv2_route_response`
- Terraform documentation resolves to paths such as `website/docs/r/apigatewayv2_route_response.html.markdown`

## Why

The OKF catalog explains Crossplane concepts, but composition agents also need deterministic, version-specific provider schemas, examples, and upstream Terraform documentation. The companion skill now instructs agents to use these tools consistently instead of falling back to generic retrieval or guessing provider mappings.

## Validation

- `python -m unittest discover -s mcp/tests -v`
- `python -m py_compile mcp/crossplane_marketplace.py mcp/provider_crd_tools.py mcp/server.py`
- `mise run lint`
