### PR TITLE
feat: authenticate GitHub MCP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The included container fetches this repository, ingests `catalog/` into a DuckDB
 docker compose up --build --detach
 ```
 
+To authenticate the server's GitHub requests, export `GITHUB_TOKEN` before
+starting the container. The token is optional.
+
 The local MCP endpoint is `http://127.0.0.1:8000/mcp`. Put it behind a TLS reverse proxy for `crossplane.mcp.jkroepke.de`.
 
 The catalog is refreshed at container startup. If fetching or ingestion fails and a previous catalog exists in the volume, the server continues with that last successful catalog.

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
+    environment:
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     volumes:
       - crossplane-v2-okf-data:/data
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,6 +6,11 @@ Format catalog and provides read-only provider package and CRD tools.
 It is intentionally not a distributable Python package: the server retains its
 small, flat module layout and is deployed by the repository's container image.
 
+## GitHub authentication
+
+Set `GITHUB_TOKEN` to authenticate GitHub API and raw-source requests. This is
+optional; without it, the server continues to use unauthenticated requests.
+
 ## Development
 
 Run commands from this directory:

--- a/mcp/github_source.py
+++ b/mcp/github_source.py
@@ -54,11 +54,13 @@ class GitHubSourceClient:
         timeout: float = 15.0,
         opener: Callable[..., Any] = urlopen,
         cache: FetchCache | None = None,
+        token: str | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self._opener = opener
         self.cache = cache or FetchCache()
+        self.token = token
 
     def get_versions(self, name: str) -> dict[str, Any]:
         source = self.resolve_source(name)
@@ -364,14 +366,14 @@ class GitHubSourceClient:
         url = f"{self.base_url}{path}"
         if query:
             url = f"{url}?{urlencode(query)}"
-        request = Request(
-            url,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "User-Agent": "okf-crossplane-v2-mcp/1.0",
-                "X-GitHub-Api-Version": "2026-03-10",
-            },
-        )
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "okf-crossplane-v2-mcp/1.0",
+            "X-GitHub-Api-Version": "2026-03-10",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = Request(url, headers=headers)
         try:
             response = self._opener(request, timeout=self.timeout)
             with response:

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -58,12 +58,14 @@ class ProviderCRDTools:
         timeout: float = 15.0,
         opener: Callable[..., Any] = urlopen,
         cache: FetchCache | None = None,
+        token: str | None = None,
     ) -> None:
         self.source_catalog = source_catalog
         self.github_raw_url = github_raw_url.rstrip("/")
         self.timeout = timeout
         self._opener = opener
         self.cache = cache or FetchCache()
+        self.token = token
 
     def search(
         self,
@@ -458,7 +460,10 @@ class ProviderCRDTools:
             f"{self.github_raw_url}/{repository}/{quote(ref, safe='')}/"
             f"{quote(path, safe='/')}"
         )
-        request = Request(url, headers={"User-Agent": "okf-crossplane-v2-mcp/1.0"})
+        headers = {"User-Agent": "okf-crossplane-v2-mcp/1.0"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = Request(url, headers=headers)
         try:
             response = self._opener(request, timeout=self.timeout)
             with response:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -40,6 +40,7 @@ github_source = GitHubSourceClient(
     base_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
     timeout=float(os.environ.get("GITHUB_API_TIMEOUT", "15")),
     cache=fetch_cache,
+    token=os.environ.get("GITHUB_TOKEN"),
 )
 provider_crds = ProviderCRDTools(
     github_source,
@@ -48,6 +49,7 @@ provider_crds = ProviderCRDTools(
     ),
     timeout=float(os.environ.get("GITHUB_API_TIMEOUT", "15")),
     cache=fetch_cache,
+    token=os.environ.get("GITHUB_TOKEN"),
 )
 
 if not db_path.is_file():

--- a/mcp/tests/test_github_source.py
+++ b/mcp/tests/test_github_source.py
@@ -4,6 +4,7 @@ import base64
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -43,6 +44,59 @@ class FakeProviderCRDTools(ProviderCRDTools):
 
 
 class GitHubSourceClientTest(unittest.TestCase):
+    def test_api_requests_include_configured_token(self) -> None:
+        request_log = []
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = b"{}"
+
+        def opener(request, timeout):
+            request_log.append((request, timeout))
+            return response
+
+        client = GitHubSourceClient(opener=opener, token="test-token")
+
+        self.assertEqual(client._request_bytes("/rate_limit"), b"{}")
+        self.assertEqual(
+            request_log[0][0].get_header("Authorization"), "Bearer test-token"
+        )
+
+    def test_api_requests_omit_authorization_without_token(self) -> None:
+        request_log = []
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = b"{}"
+
+        def opener(request, timeout):
+            request_log.append((request, timeout))
+            return response
+
+        client = GitHubSourceClient(opener=opener)
+
+        client._request_bytes("/rate_limit")
+
+        self.assertIsNone(request_log[0][0].get_header("Authorization"))
+
+    def test_raw_source_requests_include_configured_token(self) -> None:
+        request_log = []
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = b"content"
+
+        def opener(request, timeout):
+            request_log.append((request, timeout))
+            return response
+
+        tools = ProviderCRDTools(MagicMock(), opener=opener, token="test-token")
+
+        self.assertEqual(
+            tools._fetch_github_file("crossplane/crossplane", "v2.0.0", "README.md"),
+            b"content",
+        )
+        self.assertEqual(
+            request_log[0][0].get_header("Authorization"), "Bearer test-token"
+        )
+
     def _terraform_docs_tools(
         self,
         repository: str,


### PR DESCRIPTION
## Summary

- support optional `GITHUB_TOKEN` authentication for GitHub API and raw-source requests
- forward `GITHUB_TOKEN` through the self-hosted Compose configuration
- document token configuration and cover authenticated and unauthenticated requests

## Why

Unauthenticated GitHub requests are subject to lower rate limits. Supplying a token lets self-hosted MCP deployments make authenticated requests while preserving the existing unauthenticated default.

## Validation

- `cd mcp && uv run python -m unittest discover -s tests -v`
- `cd mcp && uv run ty check .`
- `cd mcp && uv run ruff check .`
- `cd mcp && uv run ruff format --check .`
- `docker compose config --quiet`
- `git diff --check`