### PR TITLE
docs: prefer Upjet cloud providers for new compositions

### DIFF
--- a/catalog/composition-developer-starter.md
+++ b/catalog/composition-developer-starter.md
@@ -24,6 +24,25 @@ Provider-specific GVKs, fields, credentials, connection keys, and external
 behavior must come from the provider release installed in the target
 environment. This route supplies no universal runnable manifest.
 
+## Default cloud-provider choice
+
+For a new Composition that needs AWS, Azure, or GCP resources, prefer the
+corresponding Upjet provider:
+
+| Cloud | Prefer for new work | Avoid introducing for new work |
+| --- | --- | --- |
+| AWS | `crossplane-contrib/provider-upjet-aws` | `crossplane-contrib/provider-aws` |
+| Azure | `crossplane-contrib/provider-upjet-azure` | `crossplane-contrib/provider-azure` |
+| GCP | `crossplane-contrib/provider-upjet-gcp` | `crossplane-contrib/provider-gcp` |
+
+This is an authoring default, not an in-place replacement rule. If a
+Composition or its target cluster already uses one of the non-Upjet providers,
+continue using that provider unless an explicit, resource-by-resource migration
+has been planned and tested. Provider packages can expose different GVKs,
+scopes, ProviderConfigs, external identities, and migration behavior. Consult
+[provider implementation families and selection](providers/provider-landscape.md)
+before selecting a package, then inspect the exact pinned provider CRD schema.
+
 ## Default function choice
 
 If the project has no existing Compositions and the requester did not name a

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,6 +1,7 @@
 # Catalog Update Log
 
 ## 2026-07-18
+* **Update**: Added a Composition-authoring default that prefers the Upjet AWS, Azure, and GCP providers for new work while retaining already-used non-Upjet providers unless a tested, resource-by-resource migration is explicitly planned.
 * **Creation**: Documented how to retrieve Crossplane provider-published connection Secret keys from release-pinned implementation sources, distinguishing destination-only CRD fields from `AdditionalConnectionDetailsFn` behavior and preserving conditional-key boundaries.
 * **Update**: Extended provider connection-detail retrieval with the typed `managed.ConnectionDetails` and runtime-publisher path used by provider-sql, separating it from Upjet-based Crossplane provider configuration.
 


### PR DESCRIPTION
## Summary
- prefer Upjet AWS, Azure, and GCP providers for new Composition work
- retain already-used non-Upjet providers unless a tested migration is planned

## Validation
- mise run validate
- mise run lint
- okf-reviewer: APPROVED