### PR TITLE
fix(mcp): include git source module in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN uv sync --frozen --no-dev
 
 COPY mcp/server.py /app/server.py
 COPY mcp/fetch_cache.py /app/fetch_cache.py
+COPY mcp/git_source.py /app/git_source.py
 COPY mcp/github_source.py /app/github_source.py
 COPY mcp/provider_crd_tools.py /app/provider_crd_tools.py
 COPY mcp/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## What changed

Adds `mcp/git_source.py` to the runtime image copy list.

## Why

The merged Git-backed provider cache imported `git_source` from `server.py`, but the Dockerfile did not copy that module into `/app`. The container crashed on startup with `ModuleNotFoundError`.

## Validation

- `mise run lint`
- Fresh `docker build` completed successfully
- Reviewer: APPROVED