### PR TITLE
fix(mcp): keep source requests responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.duckdb
 __pycache__/
 .venv/
+.env
+compose.override.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.11.29-debian-slim
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         ca-certificates \
+        build-essential \
         git \
         tini \
     && rm -rf /var/lib/apt/lists/*
@@ -19,7 +20,10 @@ RUN groupadd --gid 65532 okf \
 WORKDIR /app
 
 COPY mcp/pyproject.toml mcp/uv.lock /app/
-RUN uv sync --frozen --no-dev
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv/python" \
+    UV_PYTHON="3.14t"
+RUN uv python install "$UV_PYTHON" \
+    && uv sync --frozen --no-dev --python "$UV_PYTHON"
 
 COPY mcp/server.py /app/server.py
 COPY mcp/fetch_cache.py /app/fetch_cache.py
@@ -51,6 +55,7 @@ ENV BUNDLE_URL="https://github.com/jkroepke/okf-crossplane-v2.git" \
     GITHUB_API_TIMEOUT="15" \
     GITHUB_GIT_URL="https://github.com" \
     GITHUB_GIT_TIMEOUT="30" \
+    MCP_BLOCKING_WORKERS="4" \
     CACHE_DIR="/data/cache" \
     FETCH_CACHE_TTL_SECONDS="300" \
     FETCH_CACHE_MAX_ENTRIES="512" \

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -3,6 +3,9 @@
 This `uv`-managed Python application serves the Crossplane v2 Open Knowledge
 Format catalog and provides read-only provider package and CRD tools.
 
+`provider_crd_get_terraform_docs` returns the Terraform documentation content
+together with its immutable repository, ref, and source path.
+
 It is intentionally not a distributable Python package: the server retains its
 small, flat module layout and is deployed by the repository's container image.
 
@@ -20,6 +23,10 @@ examples, and Terraform metadata are then read from that local snapshot.
 
 Set `GITHUB_GIT_URL` (default: `https://github.com`) to use another Git host
 and `GITHUB_GIT_TIMEOUT` (default: 30 seconds) to bound a Git fetch.
+
+Provider-source work runs in a bounded thread pool so one cold-cache request
+does not block MCP health checks or unrelated clients. Set
+`MCP_BLOCKING_WORKERS` (default: 4) to tune its concurrency.
 
 ## Development
 

--- a/mcp/github_source.py
+++ b/mcp/github_source.py
@@ -114,8 +114,14 @@ class GitHubSourceClient:
         self, repository: str, pattern: str, version: str, limit: int
     ) -> dict[str, Any]:
         selected_version = self._select_version(repository, version)
-        resources = self._resources(repository, selected_version)
         normalized_pattern = pattern.strip() or "*"
+        resources = (
+            self._fetch_local_resources(
+                repository, selected_version, normalized_pattern
+            )
+            if self.source_cache is not None
+            else self._resources(repository, selected_version)
+        )
         matches = [
             resource
             for resource in resources
@@ -153,7 +159,11 @@ class GitHubSourceClient:
         selected_version = self._select_version(repository, version)
         matches = [
             item
-            for item in self._resources(repository, selected_version)
+            for item in (
+                self._fetch_local_resources(repository, selected_version, resource)
+                if self.source_cache is not None
+                else self._resources(repository, selected_version)
+            )
             if self._resource_matches(item, resource)
         ]
         if not matches:
@@ -224,12 +234,16 @@ class GitHubSourceClient:
                 resources.append(resource)
         return resources
 
-    def _fetch_local_resources(self, repository: str, ref: str) -> list[dict[str, Any]]:
+    def _fetch_local_resources(
+        self, repository: str, ref: str, pattern: str = "*"
+    ) -> list[dict[str, Any]]:
         assert self.source_cache is not None
         paths = self.source_cache.list_files(repository, ref, "package/crds/")
         resources = []
         for path in paths:
             if not path.endswith((".yaml", ".yml")):
+                continue
+            if not self._local_crd_path_might_match(path, pattern):
                 continue
             resource = self._crd_from_yaml(
                 self.source_cache.read_file(repository, ref, path).decode("utf-8"),
@@ -455,3 +469,22 @@ class GitHubSourceClient:
             fnmatch.fnmatchcase(identity.lower(), pattern.lower())
             for identity in identities
         )
+
+    @staticmethod
+    def _local_crd_path_might_match(path: str, pattern: str) -> bool:
+        """Cheaply exclude generated CRD files that cannot satisfy simple queries.
+
+        Provider CRD filenames encode the group and plural kind. A search for
+        ``*Bucket*`` therefore need not parse every generated OpenAPI schema.
+        Patterns whose identities cannot be represented by the filename retain
+        the complete scan, preserving the public wildcard semantics.
+        """
+        normalized_pattern = pattern.casefold()
+        if normalized_pattern == "*" or "?" in normalized_pattern:
+            return True
+        if "." in normalized_pattern and "/" not in normalized_pattern:
+            return True
+        literal = normalized_pattern.replace("*", "").replace("/", "_")
+        if not literal:
+            return True
+        return literal in path.casefold()

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -243,14 +243,19 @@ class ProviderCRDTools:
         terraform_resource = self._terraform_resource_name(source, resource)
         provider_prefix = terraform_source.rsplit("/", 1)[-1]
         docs_resource = terraform_resource.removeprefix(f"{provider_prefix}_")
+        docs_ref = self._version_tag(terraform_version)
+        docs_path = f"{docs_path.rstrip('/')}/{docs_resource}.html.markdown"
         return {
             "provider_name": provider,
             "provider_version": version,
             "crd": resource,
             "terraform_resource_name": terraform_resource,
             "repository": terraform_repository,
-            "ref": self._version_tag(terraform_version),
-            "path": (f"{docs_path.rstrip('/')}/{docs_resource}.html.markdown"),
+            "ref": docs_ref,
+            "path": docs_path,
+            "content": self._read_github_text(
+                terraform_repository, docs_ref, docs_path
+            ),
         }
 
     def _resolve_resource(

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +36,29 @@ def env_csv(name: str) -> list[str]:
     return [value.strip() for value in os.getenv(name, "").split(",") if value.strip()]
 
 
+def env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(
+            f"{name} must be a positive integer, received {raw!r}"
+        ) from error
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer, received {raw!r}")
+    return value
+
+
+async def run_blocking(
+    function: Callable[..., dict[str, Any]], *args: object
+) -> dict[str, Any]:
+    """Run blocking source work outside the Streamable HTTP event loop."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(blocking_work_pool, partial(function, *args))
+
+
 def ensure_writable_directory(path: Path) -> Path:
     """Create and verify the directory used for persistent source snapshots."""
     probe_path: Path | None = None
@@ -53,6 +80,10 @@ cache_dir = ensure_writable_directory(
     Path(os.environ.get("CACHE_DIR", "/data/cache")).resolve()
 )
 bundle_name = os.environ.get("BUNDLE_NAME", "crossplane-v2-okf")
+blocking_work_pool = ThreadPoolExecutor(
+    max_workers=env_positive_int("MCP_BLOCKING_WORKERS", 4),
+    thread_name_prefix="mcp-source",
+)
 fetch_cache = FetchCache(
     ttl_seconds=float(os.environ.get("FETCH_CACHE_TTL_SECONDS", "300")),
     max_entries=int(os.environ.get("FETCH_CACHE_MAX_ENTRIES", "512")),
@@ -102,7 +133,7 @@ mcp.settings.transport_security = TransportSecuritySettings(
 
 
 @mcp.tool()
-def get_versions(name: str) -> dict[str, Any]:
+async def get_versions(name: str) -> dict[str, Any]:
     """Resolve an OSS source and list its available versions.
 
     The name can be a short package name such as ``provider-aws`` or
@@ -112,11 +143,11 @@ def get_versions(name: str) -> dict[str, Any]:
     the provider CRD tools with ``versions.latest`` or a listed recent stable
     version. Counts summarize additional historical and prerelease tags.
     """
-    return github_source.get_versions(name)
+    return await run_blocking(github_source.get_versions, name)
 
 
 @mcp.tool()
-def provider_crd_search(
+async def provider_crd_search(
     provider_name: str,
     provider_version: str,
     crd_search_term: str,
@@ -126,11 +157,13 @@ def provider_crd_search(
     The search term is a case-insensitive shell wildcard matched against the
     group, kind, group/kind, and Kind.group identities.
     """
-    return provider_crds.search(provider_name, provider_version, crd_search_term)
+    return await run_blocking(
+        provider_crds.search, provider_name, provider_version, crd_search_term
+    )
 
 
 @mcp.tool()
-def provider_crd_get_definition(
+async def provider_crd_get_definition(
     provider_name: str,
     provider_version: str,
     crd_name: str,
@@ -142,11 +175,13 @@ def provider_crd_get_definition(
     containing apiVersion and kind. Optionally select a subtree with a dotted
     path such as ``.spec`` or ``.spec.versions[0]``.
     """
-    return provider_crds.get_definition(provider_name, provider_version, crd_name, path)
+    return await run_blocking(
+        provider_crds.get_definition, provider_name, provider_version, crd_name, path
+    )
 
 
 @mcp.tool()
-def provider_crd_get_examples(
+async def provider_crd_get_examples(
     provider_name: str,
     provider_version: str,
     crd_name: str,
@@ -156,21 +191,26 @@ def provider_crd_get_examples(
     When no API version is included in ``crd_name``, the latest served CRD API
     version is used for the example directory.
     """
-    return provider_crds.get_examples(provider_name, provider_version, crd_name)
+    return await run_blocking(
+        provider_crds.get_examples, provider_name, provider_version, crd_name
+    )
 
 
 @mcp.tool()
-def provider_crd_get_terraform_docs(
+async def provider_crd_get_terraform_docs(
     provider_name: str,
     provider_version: str,
     crd_name: str,
 ) -> dict[str, Any]:
-    """Get the Terraform documentation repository and path for an Upjet CRD.
+    """Get Terraform documentation content and source metadata for an Upjet CRD.
 
     The provider Makefile selects the Terraform repository and version. The
-    generated controller identifies the exact Terraform resource name.
+    generated controller identifies the exact Terraform resource name. The
+    response includes the immutable repository, ref, path, and document content.
     """
-    return provider_crds.get_terraform_docs(provider_name, provider_version, crd_name)
+    return await run_blocking(
+        provider_crds.get_terraform_docs, provider_name, provider_version, crd_name
+    )
 
 
 @mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)

--- a/mcp/tests/test_github_source.py
+++ b/mcp/tests/test_github_source.py
@@ -93,6 +93,37 @@ spec:
             [(repository, version, "package/crds/bucket.yaml")],
         )
 
+    def test_search_skips_unrelated_local_crd_schemas(self) -> None:
+        repository = "crossplane-contrib/provider-upjet-aws"
+        version = "v2.6.0"
+        source_cache = FakeGitSourceCache(
+            {
+                f"{repository}@{version}:package/crds/buckets.yaml": b"""
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  group: s3.aws.m.upbound.io
+  scope: Namespaced
+  names:
+    kind: Bucket
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+""",
+                f"{repository}@{version}:package/crds/instances.yaml": b"invalid",
+            }
+        )
+        client = GitHubSourceClient(source_cache=source_cache)  # type: ignore[arg-type]
+
+        result = client.search_resources(repository, "*Bucket*", version)
+
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(
+            source_cache.read_calls,
+            [(repository, version, "package/crds/buckets.yaml")],
+        )
+
     def test_provider_files_read_from_the_local_git_cache(self) -> None:
         repository = "crossplane-contrib/provider-upjet-aws"
         version = "v2.6.0"
@@ -202,6 +233,8 @@ spec:
             }
         )
         source_scope = "namespaced" if scope == "Namespaced" else "cluster"
+        provider_prefix = terraform_source.rsplit("/", 1)[-1]
+        docs_resource = terraform_resource.removeprefix(f"{provider_prefix}_")
         return FakeProviderCRDTools(
             source,
             {
@@ -214,6 +247,7 @@ export TERRAFORM_DOCS_PATH := website/docs/r
                 f"{repository}@{version}:internal/controller/{source_scope}/{service}/{directory}/zz_controller.go": (
                     f'o.Provider.Resources["{terraform_resource}"]'
                 ),
+                f"{terraform_repository}@v1.2.3:website/docs/r/{docs_resource}.html.markdown": "# Terraform documentation\n",
             },
         )
 
@@ -379,6 +413,7 @@ export TERRAFORM_DOCS_PATH := website/docs/r
                 f"{repository}@{version}:internal/controller/namespaced/s3/bucket/zz_controller.go": (
                     'o.Provider.Resources["aws_s3_bucket"]'
                 ),
+                "hashicorp/terraform-provider-aws@v6.53.0:website/docs/r/s3_bucket.html.markdown": "# S3 bucket\n",
             },
         )
 
@@ -394,6 +429,7 @@ export TERRAFORM_DOCS_PATH := website/docs/r
         self.assertEqual(result["repository"], "hashicorp/terraform-provider-aws")
         self.assertEqual(result["ref"], "v6.53.0")
         self.assertEqual(result["path"], "website/docs/r/s3_bucket.html.markdown")
+        self.assertEqual(result["content"], "# S3 bucket\n")
 
     def test_keycloak_and_openstack_terraform_docs_resolve_end_to_end(self) -> None:
         cases = [
@@ -449,6 +485,7 @@ export TERRAFORM_DOCS_PATH := website/docs/r
                 self.assertEqual(result["repository"], terraform_repository)
                 self.assertEqual(result["ref"], "v1.2.3")
                 self.assertEqual(result["path"], f"website/docs/r/{documentation}")
+                self.assertEqual(result["content"], "# Terraform documentation\n")
 
     def test_non_upjet_examples_resolve_without_terraform_metadata(
         self,

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -250,6 +250,9 @@ export TERRAFORM_DOCS_PATH ?= website/docs/r
             github_files[f"{source}:{controller_path}"] = (
                 f'o.Provider.Resources["{terraform_name}"]'
             )
+            github_files[f"hashicorp/terraform-provider-aws@v6.53.0:{docs_path}"] = (
+                f"# {terraform_name}\n"
+            )
         tools = FakeProviderCRDTools(marketplace, github_files)
 
         for kind, _, terraform_name, docs_path in cases:
@@ -265,6 +268,7 @@ export TERRAFORM_DOCS_PATH ?= website/docs/r
                 self.assertEqual(result["ref"], "v6.53.0")
                 self.assertEqual(result["path"], docs_path)
                 self.assertEqual(result["terraform_resource_name"], terraform_name)
+                self.assertEqual(result["content"], f"# {terraform_name}\n")
 
     def test_missing_crd_returns_clear_error(self) -> None:
         tools = FakeProviderCRDTools(FakeMarketplace())


### PR DESCRIPTION
## Summary

- Run blocking provider-source operations in a bounded worker pool so MCP health checks and unrelated clients remain responsive.
- Return the resolved Terraform documentation content with immutable source metadata.
- Avoid parsing unrelated cached CRD schemas for simple searches, and update the container runtime configuration.

## Why

Cold-cache Git and provider-source work can otherwise occupy the Streamable HTTP event loop. Terraform documentation callers also need the actual resolved document, not only its location.

## Validation

- `mise run test` (24 tests)
- `uv run --project mcp ruff check .`
- `uv run --project mcp ruff format --check .`