### PR TITLE
Fix provider package example lookup

### DIFF
--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -177,7 +177,8 @@ class ProviderCRDTools:
         api_version = self._resource_api_version(resource)
         service = self._resource_service(resource)
         scope = self._resource_scope(resource)
-        filename = f"{self._kind_directory(resource['kind'])}.yaml"
+        kind_directory = self._kind_directory(str(resource["kind"]))
+        filename = f"{kind_directory}.yaml"
         candidates = [
             (
                 True,
@@ -189,9 +190,24 @@ class ProviderCRDTools:
             ),
             (
                 False,
-                f"examples/{self._kind_directory(resource['kind'])}/{scope}/{api_version}/{filename}",
+                f"examples/{kind_directory}/{scope}/{api_version}/{filename}",
+            ),
+            (
+                False,
+                f"examples/{kind_directory}/{filename}",
+            ),
+            (
+                False,
+                f"examples/{scope}/{service}/{filename}",
             ),
         ]
+        if str(resource["kind"]).casefold() == "providerconfig":
+            candidates.append(
+                (
+                    False,
+                    f"examples/{scope}/{service}/config.yaml",
+                )
+            )
         examples = [
             {
                 "repository": source.repository,

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -187,6 +187,10 @@ class ProviderCRDTools:
                 False,
                 f"examples/{service}/{scope}/{api_version}/{filename}",
             ),
+            (
+                False,
+                f"examples/{self._kind_directory(resource['kind'])}/{scope}/{api_version}/{filename}",
+            ),
         ]
         examples = [
             {

--- a/mcp/provider_crd_tools.py
+++ b/mcp/provider_crd_tools.py
@@ -8,6 +8,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
+import yaml
+
 from fetch_cache import IMMUTABLE_SOURCE_TTL_SECONDS, FetchCache
 from git_source import GitSourceCache
 
@@ -175,6 +177,101 @@ class ProviderCRDTools:
         )
         source = self._provider_source(provider, version)
         api_version = self._resource_api_version(resource)
+        examples = self._source_cache_examples(source, resource, api_version)
+        if examples is None:
+            examples = self._candidate_examples(source, resource, api_version)
+        if not examples:
+            target = f"{resource['group']}/{api_version}/{resource['kind']}"
+            raise ProviderToolError(
+                f"No examples found in {source.repository}@{source.ref}. "
+                f"No example document matches {target}"
+            )
+        return {
+            "provider_name": provider,
+            "provider_version": version,
+            "crd": resource,
+            "examples": examples,
+        }
+
+    def _source_cache_examples(
+        self,
+        source: ProviderSource,
+        resource: dict[str, Any],
+        api_version: str,
+    ) -> list[dict[str, Any]] | None:
+        if self.source_cache is None:
+            return None
+        inventory = self.cache.get_or_load(
+            ("provider-example-inventory", source.repository, source.ref),
+            lambda: self._source_cache_example_inventory(source),
+            ttl_seconds=self._source_ttl(source.ref),
+        )
+        target_api_version = f"{resource['group']}/{api_version}"
+        matches: dict[tuple[str, bool], list[int]] = {}
+        for entry in inventory:
+            if (
+                entry["api_version"] != target_api_version
+                or entry["kind"] != resource["kind"]
+            ):
+                continue
+            key = (entry["path"], entry["generated"])
+            matches.setdefault(key, []).append(entry["document_index"])
+        return [
+            {
+                "repository": source.repository,
+                "ref": source.ref,
+                "path": path,
+                "generated": generated,
+                "document_indexes": document_indexes,
+            }
+            for (path, generated), document_indexes in sorted(matches.items())
+        ]
+
+    def _source_cache_example_inventory(
+        self, source: ProviderSource
+    ) -> list[dict[str, Any]]:
+        assert self.source_cache is not None
+        inventory: list[dict[str, Any]] = []
+        for prefix, generated in (("examples/", False), ("examples-generated/", True)):
+            for path in self.source_cache.list_files(
+                source.repository, source.ref, prefix
+            ):
+                if not path.endswith((".yaml", ".yml")):
+                    continue
+                try:
+                    documents = yaml.safe_load_all(
+                        self.source_cache.read_file(
+                            source.repository, source.ref, path
+                        ).decode("utf-8")
+                    )
+                    for document_index, document in enumerate(documents):
+                        if not isinstance(document, dict):
+                            continue
+                        api_version = document.get("apiVersion")
+                        kind = document.get("kind")
+                        if not isinstance(api_version, str) or not isinstance(
+                            kind, str
+                        ):
+                            continue
+                        inventory.append(
+                            {
+                                "path": path,
+                                "generated": generated,
+                                "api_version": api_version,
+                                "kind": kind,
+                                "document_index": document_index,
+                            }
+                        )
+                except UnicodeDecodeError, yaml.YAMLError:
+                    continue
+        return inventory
+
+    def _candidate_examples(
+        self,
+        source: ProviderSource,
+        resource: dict[str, Any],
+        api_version: str,
+    ) -> list[dict[str, Any]]:
         service = self._resource_service(resource)
         scope = self._resource_scope(resource)
         kind_directory = self._kind_directory(str(resource["kind"]))
@@ -208,7 +305,7 @@ class ProviderCRDTools:
                     f"examples/{scope}/{service}/config.yaml",
                 )
             )
-        examples = [
+        return [
             {
                 "repository": source.repository,
                 "ref": source.ref,
@@ -218,18 +315,6 @@ class ProviderCRDTools:
             for generated, path in candidates
             if self._github_file_exists(source.repository, source.ref, path)
         ]
-        if not examples:
-            attempted = ", ".join(path for _, path in candidates)
-            raise ProviderToolError(
-                f"No examples found in {source.repository}@{source.ref}. "
-                f"Tried: {attempted}"
-            )
-        return {
-            "provider_name": provider,
-            "provider_version": version,
-            "crd": resource,
-            "examples": examples,
-        }
 
     def get_terraform_docs(
         self,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -186,10 +186,12 @@ async def provider_crd_get_examples(
     provider_version: str,
     crd_name: str,
 ) -> dict[str, Any]:
-    """Get GitHub repository paths for generated and handwritten CRD examples.
+    """Get all matching YAML examples from an immutable provider source snapshot.
 
-    When no API version is included in ``crd_name``, the latest served CRD API
-    version is used for the example directory.
+    Every YAML document under ``examples/`` and ``examples-generated/`` is
+    considered. Each result includes the zero-based indexes of matching
+    documents when a file contains multiple YAML documents. When no API version
+    is included in ``crd_name``, the latest served CRD API version is selected.
     """
     return await run_blocking(
         provider_crds.get_examples, provider_name, provider_version, crd_name

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -11,11 +11,11 @@ from provider_crd_tools import ProviderCRDTools, ProviderToolError, SourceFileNo
 
 RESOURCES = [
     {
-        "group": "aws.upbound.io",
+        "group": "aws.m.upbound.io",
         "kind": "ProviderConfig",
         "versions": ["v1beta1"],
         "storage_version": "v1beta1",
-        "scope": "Cluster",
+        "scope": "Namespaced",
     },
     {
         "group": "identity.example.io",
@@ -217,6 +217,33 @@ class ProviderCRDToolsTest(unittest.TestCase):
         self.assertEqual(result["examples"][0]["path"], generated)
         self.assertTrue(result["examples"][0]["generated"])
         self.assertEqual(result["examples"][1]["path"], handwritten)
+
+    def test_examples_support_package_level_provider_config_layout(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-upjet-aws@v2.6.0"
+        package_level = "examples/providerconfig/namespaced/v1beta1/providerconfig.yaml"
+        tools = FakeProviderCRDTools(
+            marketplace,
+            {f"{source}:{package_level}": "provider config"},
+        )
+
+        result = tools.get_examples(
+            "crossplane-contrib/provider-upjet-aws",
+            "v2.6.0",
+            "aws.m.upbound.io/v1beta1/ProviderConfig",
+        )
+
+        self.assertEqual(
+            result["examples"],
+            [
+                {
+                    "repository": "crossplane-contrib/provider-upjet-aws",
+                    "ref": "v2.6.0",
+                    "path": package_level,
+                    "generated": False,
+                }
+            ],
+        )
 
     def test_terraform_docs_use_makefile_and_generated_controller(self) -> None:
         marketplace = FakeMarketplace()

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -67,6 +67,13 @@ RESOURCES = [
         "scope": "Namespaced",
     },
     {
+        "group": "postgresql.sql.m.crossplane.io",
+        "kind": "ProviderConfig",
+        "versions": ["v1alpha1"],
+        "storage_version": "v1alpha1",
+        "scope": "Namespaced",
+    },
+    {
         "group": "keycloak.crossplane.io",
         "kind": "ProviderConfig",
         "versions": ["v1beta1"],
@@ -119,6 +126,24 @@ class FakeMarketplace:
                 "kind": "CustomResourceDefinition",
             }
         }
+
+
+class FakeGitSourceCache:
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self.files = files
+        self.list_calls: list[tuple[str, str, str]] = []
+
+    def list_files(self, repository: str, ref: str, prefix: str) -> list[str]:
+        self.list_calls.append((repository, ref, prefix))
+        return sorted(
+            path
+            for key in self.files
+            if (path := key.removeprefix(f"{repository}@{ref}:")) != key
+            and path.startswith(prefix)
+        )
+
+    def read_file(self, repository: str, ref: str, path: str) -> bytes:
+        return self.files[f"{repository}@{ref}:{path}"]
 
 
 class FakeProviderCRDTools(ProviderCRDTools):
@@ -307,6 +332,86 @@ class ProviderCRDToolsTest(unittest.TestCase):
 
                 self.assertEqual(result["examples"][0]["path"], path)
                 self.assertFalse(result["examples"][0]["generated"])
+
+    def test_examples_scan_cached_snapshot_and_match_all_yaml_documents(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-sql@v0.15.0"
+        examples = {
+            f"{source}:examples/namespaced/postgresql/grant.yaml": b"""
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Grant
+---
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Role
+---
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Grant
+""",
+            f"{source}:examples-generated/namespaced/postgresql/grant.yaml": b"""
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: Grant
+""",
+            f"{source}:examples/namespaced/postgresql/config.yaml": b"""
+apiVersion: postgresql.sql.m.crossplane.io/v1alpha1
+kind: ProviderConfig
+""",
+            f"{source}:examples/not-a-manifest.yaml": b"{{ not valid yaml",
+        }
+        source_cache = FakeGitSourceCache(examples)
+        tools = ProviderCRDTools(
+            marketplace,
+            source_cache=source_cache,  # type: ignore[arg-type]
+        )
+
+        grants = tools.get_examples(
+            "crossplane-contrib/provider-sql",
+            "v0.15.0",
+            "postgresql.sql.m.crossplane.io/v1alpha1/Grant",
+        )
+        provider_configs = tools.get_examples(
+            "crossplane-contrib/provider-sql",
+            "v0.15.0",
+            "postgresql.sql.m.crossplane.io/v1alpha1/ProviderConfig",
+        )
+
+        self.assertEqual(
+            grants["examples"],
+            [
+                {
+                    "repository": "crossplane-contrib/provider-sql",
+                    "ref": "v0.15.0",
+                    "path": "examples-generated/namespaced/postgresql/grant.yaml",
+                    "generated": True,
+                    "document_indexes": [0],
+                },
+                {
+                    "repository": "crossplane-contrib/provider-sql",
+                    "ref": "v0.15.0",
+                    "path": "examples/namespaced/postgresql/grant.yaml",
+                    "generated": False,
+                    "document_indexes": [0, 2],
+                },
+            ],
+        )
+        self.assertEqual(
+            provider_configs["examples"][0]["path"],
+            "examples/namespaced/postgresql/config.yaml",
+        )
+        self.assertEqual(
+            provider_configs["examples"][0]["document_indexes"],
+            [0],
+        )
+        self.assertEqual(
+            source_cache.list_calls,
+            [
+                ("crossplane-contrib/provider-sql", "v0.15.0", "examples/"),
+                (
+                    "crossplane-contrib/provider-sql",
+                    "v0.15.0",
+                    "examples-generated/",
+                ),
+            ],
+        )
 
     def test_examples_support_kind_directory_layout_without_scope(self) -> None:
         marketplace = FakeMarketplace()

--- a/mcp/tests/test_provider_crd_tools.py
+++ b/mcp/tests/test_provider_crd_tools.py
@@ -45,6 +45,34 @@ RESOURCES = [
         "storage_version": "v1beta1",
         "scope": "Namespaced",
     },
+    {
+        "group": "mysql.sql.m.crossplane.io",
+        "kind": "ProviderConfig",
+        "versions": ["v1alpha1"],
+        "storage_version": "v1alpha1",
+        "scope": "Namespaced",
+    },
+    {
+        "group": "mssql.sql.m.crossplane.io",
+        "kind": "ProviderConfig",
+        "versions": ["v1alpha1"],
+        "storage_version": "v1alpha1",
+        "scope": "Namespaced",
+    },
+    {
+        "group": "postgresql.sql.m.crossplane.io",
+        "kind": "Grant",
+        "versions": ["v1alpha1"],
+        "storage_version": "v1alpha1",
+        "scope": "Namespaced",
+    },
+    {
+        "group": "keycloak.crossplane.io",
+        "kind": "ProviderConfig",
+        "versions": ["v1beta1"],
+        "storage_version": "v1beta1",
+        "scope": "Namespaced",
+    },
 ]
 
 
@@ -144,8 +172,10 @@ class ProviderCRDToolsTest(unittest.TestCase):
                 500,
             ),
         )
-        self.assertEqual(result["count"], 1)
-        self.assertEqual(result["crds"][0]["kind"], "ProviderConfig")
+        self.assertTrue(result["crds"])
+        self.assertTrue(
+            all(resource["kind"] == "ProviderConfig" for resource in result["crds"])
+        )
 
     def test_crd_search_results_are_cached(self) -> None:
         marketplace = FakeMarketplace()
@@ -244,6 +274,57 @@ class ProviderCRDToolsTest(unittest.TestCase):
                 }
             ],
         )
+
+    def test_examples_support_sql_service_subpaths(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-sql@v0.15.0"
+        cases = [
+            (
+                "mysql.sql.m.crossplane.io/v1alpha1/ProviderConfig",
+                "examples/namespaced/mysql/config.yaml",
+            ),
+            (
+                "mssql.sql.m.crossplane.io/v1alpha1/ProviderConfig",
+                "examples/namespaced/mssql/config.yaml",
+            ),
+            (
+                "postgresql.sql.m.crossplane.io/v1alpha1/Grant",
+                "examples/namespaced/postgresql/grant.yaml",
+            ),
+        ]
+        tools = FakeProviderCRDTools(
+            marketplace,
+            {f"{source}:{path}": "example" for _, path in cases},
+        )
+
+        for crd_name, path in cases:
+            with self.subTest(crd_name=crd_name):
+                result = tools.get_examples(
+                    "crossplane-contrib/provider-sql",
+                    "v0.15.0",
+                    crd_name,
+                )
+
+                self.assertEqual(result["examples"][0]["path"], path)
+                self.assertFalse(result["examples"][0]["generated"])
+
+    def test_examples_support_kind_directory_layout_without_scope(self) -> None:
+        marketplace = FakeMarketplace()
+        source = "crossplane-contrib/provider-keycloak@main"
+        path = "examples/providerconfig/providerconfig.yaml"
+        tools = FakeProviderCRDTools(
+            marketplace,
+            {f"{source}:{path}": "provider config"},
+        )
+
+        result = tools.get_examples(
+            "crossplane-contrib/provider-keycloak",
+            "main",
+            "keycloak.crossplane.io/v1beta1/ProviderConfig",
+        )
+
+        self.assertEqual(result["examples"][0]["path"], path)
+        self.assertFalse(result["examples"][0]["generated"])
 
     def test_terraform_docs_use_makefile_and_generated_controller(self) -> None:
         marketplace = FakeMarketplace()


### PR DESCRIPTION
## Summary

Replaces provider-example path guessing with exhaustive discovery from the shared immutable provider source snapshot.

- scans all YAML files under `examples/` and `examples-generated/`
- parses every YAML document, including multi-document files
- returns every exact `apiVersion`/`kind` match with zero-based `document_indexes`
- caches the parsed inventory per repository tag and reuses the existing Git snapshot cache

## Root cause

`provider_crd_get_examples` previously inferred a few repository layouts from the CRD group and kind. Provider repositories use varied directory layouts, and one file can contain multiple matching manifests.

## Validation

- `mise run lint` (OKF validation and 28 MCP unit tests)
- `uv run ty check`
- Required reviewer approval