### PR TITLE
Close MCP Git source repository handles

### DIFF
--- a/mcp/git_source.py
+++ b/mcp/git_source.py
@@ -51,24 +51,25 @@ class GitSourceCache:
     def list_files(self, repository: str, ref: str, prefix: str) -> list[str]:
         """List blob paths below ``prefix`` in one cached provider snapshot."""
         snapshot = self._snapshot(repository, ref)
-        repo = Repo(snapshot.path)
-        tree: Any = repo.commit(snapshot.commit).tree
-        return sorted(
-            str(item.path)
-            for item in tree.traverse()
-            if item.type == "blob" and item.path.startswith(prefix)
-        )
+        with Repo(snapshot.path) as repo:
+            tree: Any = repo.commit(snapshot.commit).tree
+            return sorted(
+                str(item.path)
+                for item in tree.traverse()
+                if item.type == "blob" and item.path.startswith(prefix)
+            )
 
     def read_file(self, repository: str, ref: str, path: str) -> bytes:
         """Read one file from a cached provider snapshot without a checkout."""
         snapshot = self._snapshot(repository, ref)
         try:
-            blob: Any = Repo(snapshot.path).commit(snapshot.commit).tree / path
+            with Repo(snapshot.path) as repo:
+                blob: Any = repo.commit(snapshot.commit).tree / path
+                if blob.type != "blob":
+                    raise FileNotFoundError(path)
+                return cast(bytes, blob.data_stream.read())
         except KeyError as error:
             raise FileNotFoundError(path) from error
-        if blob.type != "blob":
-            raise FileNotFoundError(path)
-        return cast(bytes, blob.data_stream.read())
 
     def _snapshot(self, repository: str, ref: str) -> GitSnapshot:
         owner, name = self._repository_parts(repository)
@@ -102,7 +103,7 @@ class GitSourceCache:
             )
             if not tag_listing.strip():
                 raise GitSourceError(f"Provider version is not a Git tag: {ref}")
-            repo = Repo.clone_from(
+            with Repo.clone_from(
                 source_url,
                 temporary_path,
                 bare=True,
@@ -110,8 +111,8 @@ class GitSourceCache:
                 depth=1,
                 single_branch=True,
                 kill_after_timeout=self.timeout,
-            )
-            commit = repo.commit(f"{tag_ref}^{{commit}}").hexsha
+            ) as repo:
+                commit = repo.commit(f"{tag_ref}^{{commit}}").hexsha
             metadata = {
                 "commit": commit,
                 "fetched_at": time.time(),

--- a/mcp/tests/test_git_source.py
+++ b/mcp/tests/test_git_source.py
@@ -4,15 +4,82 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from git import Repo
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from git_source import GitSourceCache, GitSourceError
+from git_source import GitSnapshot, GitSourceCache, GitSourceError
 
 
 class GitSourceCacheTest(unittest.TestCase):
+    def test_list_files_closes_repository(self) -> None:
+        cache = GitSourceCache(Path("cache"))
+        snapshot = GitSnapshot(Path("snapshot"), "a" * 40)
+        blob = MagicMock(type="blob", path="examples/bucket.yaml")
+        tree = MagicMock()
+        tree.traverse.return_value = [blob]
+
+        with (
+            patch.object(cache, "_snapshot", return_value=snapshot),
+            patch("git_source.Repo") as repository_class,
+        ):
+            repository = repository_class.return_value
+            repository.__enter__.return_value = repository
+            repository.commit.return_value.tree = tree
+
+            self.assertEqual(
+                cache.list_files("example/provider", "v1.2.3", "examples/"),
+                ["examples/bucket.yaml"],
+            )
+
+        repository.__exit__.assert_called_once_with(None, None, None)
+
+    def test_read_file_closes_repository(self) -> None:
+        cache = GitSourceCache(Path("cache"))
+        snapshot = GitSnapshot(Path("snapshot"), "a" * 40)
+        blob = MagicMock(type="blob")
+        blob.data_stream.read.return_value = b"contents"
+
+        with (
+            patch.object(cache, "_snapshot", return_value=snapshot),
+            patch("git_source.Repo") as repository_class,
+        ):
+            repository = repository_class.return_value
+            repository.__enter__.return_value = repository
+            repository.commit.return_value.tree.__truediv__.return_value = blob
+
+            self.assertEqual(
+                cache.read_file("example/provider", "v1.2.3", "README.md"),
+                b"contents",
+            )
+
+        repository.__exit__.assert_called_once_with(None, None, None)
+
+    def test_clone_snapshot_closes_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            cache = GitSourceCache(Path(temporary_directory) / "cache")
+            snapshot_path = Path(temporary_directory) / "snapshot"
+            repository = MagicMock()
+            repository.__enter__.return_value = repository
+            repository.commit.return_value.hexsha = "a" * 40
+
+            with (
+                patch("git_source.Git") as git_class,
+                patch.object(Repo, "clone_from", return_value=repository),
+            ):
+                git_class.return_value.ls_remote.return_value = (
+                    "a" * 40 + "\trefs/tags/v1.2.3\n"
+                )
+
+                snapshot = cache._clone_snapshot(
+                    "example/provider", "v1.2.3", snapshot_path
+                )
+
+            self.assertEqual(snapshot.commit, "a" * 40)
+            repository.__exit__.assert_called_once_with(None, None, None)
+
     def test_caches_one_immutable_snapshot_per_repository_and_tag(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)


### PR DESCRIPTION
## Summary

- Close GitPython repository handles after source snapshot listing, reading, and cloning.
- Add lifecycle regression tests for each repository-opening path.

## Root cause and impact

`provider_crd_get_examples` scans cached source files and repeatedly opened GitPython `Repo` instances without deterministic cleanup. The MCP process could therefore exhaust its open-file-descriptor limit and fail requests with `[Errno 24] Too many open files`.

Each `Repo` now uses its context manager, so cleanup occurs on successful reads and exceptions alike.

## Validation

- `mise run lint` (OKF validation and 31 MCP unit tests)
- `uv run --directory mcp ruff check .`
- `uv run --directory mcp ruff format --check .`
- `uv run --directory mcp ty check .`
