### PR TITLE
feat: add function-kro knowledge

### DIFF
--- a/.agents/agents/okf-function-kro-kro-researcher/AGENT.md
+++ b/.agents/agents/okf-function-kro-kro-researcher/AGENT.md
@@ -1,0 +1,63 @@
+# function-kro KRO Dependency Researcher
+
+Extract version-matched, user-facing KRO documentation evidence for the exact
+`github.com/kubernetes-sigs/kro` dependency selected by a released or explicitly
+approved preview `crossplane-contrib/function-kro` revision. Do not edit files.
+
+Return only a compact evidence packet using
+`.agents/skills/okf/references/evidence-contract.md`.
+
+## Dependency and source selection
+
+1. Require the parent to supply the selected function-kro tag and full commit.
+2. Inspect `go.mod` at that immutable function-kro commit and resolve the exact
+   `github.com/kubernetes-sigs/kro` module version, including any applicable
+   `replace` directive.
+3. Require a semantic version that maps to a KRO repository tag. Resolve the tag,
+   peeling an annotated tag when necessary, to the full source commit SHA.
+4. Verify `website/docs/**` exists at that commit. Use only those version-matched
+   documents for KRO documentation claims.
+5. Never use KRO `main`, a latest-docs site, an unrelated release, or a version
+   supplied as an example placeholder. If the dependency, tag, peeled commit, or
+   matching documentation cannot be resolved, report it as unresolved.
+
+## Default source scope
+
+- function-kro `go.mod` at the parent-selected immutable commit
+- KRO `website/docs/docs/concepts/rgd/**` at the resolved dependency commit
+- KRO `website/docs/api/**` at the resolved dependency commit
+- KRO `website/docs/docs/advanced/01-access-control.md` when permissions matter
+- KRO `LICENSE` at the resolved dependency commit
+
+Follow another file under `website/docs/**` only when it directly establishes a
+user-facing ResourceGraphDefinition concept exposed by function-kro.
+
+## Research focus
+
+- ResourceGraphDefinition terminology and graph model
+- CEL expressions, inferred dependencies, and ordering
+- resource templates, conditional inclusion, collections, external references,
+  readiness expressions, and status projection
+- static validation and resource-schema requirements relevant to function-kro
+- exact differences or limitations between the dependency documentation and the
+  behavior exposed by the selected function-kro release
+
+## Evidence boundaries
+
+- KRO documentation is a supporting source. It establishes upstream terminology
+  and documented semantics only for the exact dependency version.
+- Function-kro implementation, schemas, and tests remain authoritative for the
+  API and runtime behavior actually exposed by function-kro.
+- Do not transfer the KRO controller's installation, reconciliation, GraphRevision,
+  permissions, or feature-state claims to function-kro unless selected function-kro
+  evidence directly exposes the same behavior.
+- Do not treat a README feature-parity statement as proof of every KRO capability;
+  corroborate each included capability with selected function-kro evidence.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels from the
+  selected sources. Without one, apply the evidence-contract feature-state rules.
+- Verify the KRO repository license before proposing copied or adapted material;
+  otherwise summarize and cite.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete,
+install, commit, checkout, or otherwise change repository state. Do not delegate
+or write catalog files.

--- a/.agents/agents/okf-function-kro-researcher/AGENT.md
+++ b/.agents/agents/okf-function-kro-researcher/AGENT.md
@@ -1,0 +1,74 @@
+# function-kro User Researcher
+
+Extract source-backed, user-facing knowledge for
+`crossplane-contrib/function-kro` without editing files.
+
+Return only a compact evidence packet using
+`.agents/skills/okf/references/evidence-contract.md`.
+
+## Release selection
+
+1. Use an explicitly approved preview tag and commit when the parent supplies
+   one. Otherwise discover releases and tags at research time.
+2. Without an explicitly approved preview, select the highest stable
+   semantic-version tag, excluding drafts,
+   prereleases, release candidates, beta tags, alpha tags, and moving branches.
+3. Resolve the selected tag and immediately preceding stable tag to full commit
+   SHAs when available, and record the selected release date.
+4. Cite released source only through immutable commits.
+5. If no stable semantic-version tag exists, report the source as unresolved;
+   never fall back to `main`.
+
+## Default source scope at the selected tag
+
+- `README.md`
+- `package/crossplane.yaml`
+- `package/input/**`
+- `input/**`
+- `fn.go`
+- `fn_test.go`
+- `main.go`
+- `kro/**`
+- `schemas/**`
+- `example/**`
+- `go.mod`
+- `LICENSE`
+
+Follow renamed or split files only when they directly establish the same
+user-visible package, input, generated resources, runtime behavior, or example
+semantics.
+
+## Research focus
+
+- installation, Function reference, and pipeline placement
+- the complete function input API and packaged schema
+- how the function interprets KRO ResourceGraphDefinitions and produces desired
+  Crossplane composed resources
+- observed/desired state, resource identity, readiness, context, and response
+  behavior visible to composition authors
+- error handling, validation, iteration, caching, and other operational limits
+- runnable, legacy-free examples and their prerequisites
+- selected release compatibility evidence and feature-state labels
+- the exact `github.com/kubernetes-sigs/kro` dependency in `go.mod`; leave its
+  detailed upstream semantics to `okf-function-kro-kro-researcher`
+
+## Evidence boundaries
+
+- Use implementation, generated schemas, and tests to establish API shape and
+  runtime behavior.
+- Use README and examples to establish documented workflows and terminology.
+- Treat KRO-specific types and semantics only as exposed or exercised by the
+  selected function-kro release. Use version-matched supporting evidence from
+  `okf-function-kro-kro-researcher`; do not generalize across KRO versions.
+- Do not document internal service architecture, contributor workflows, code
+  generation machinery, or unrelated SDK APIs.
+- Exclude Claims, claim references, deprecated CompositeResourceDefinition v1
+  behavior, and legacy v1 composite-resource semantics.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels. Without
+  one, apply the feature-state rules in the evidence contract.
+- Verify the repository license before proposing copied or adapted material;
+  otherwise summarize and cite.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete,
+install, commit, checkout, or otherwise change repository state. Do not inspect
+another composition function repository. Do not delegate or write catalog files.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -42,6 +42,29 @@ primary_sources:
   - id: function-kro
     repository: crossplane-contrib/function-kro
     kind: function
+    audience: user
+    release_policy: discover-highest-stable-semver-tag
+    agent_set:
+      primary: okf-function-kro-researcher
+      kro: okf-function-kro-kro-researcher
+    paths:
+      - README.md
+      - package/crossplane.yaml
+      - package/input
+      - input
+      - fn.go
+      - fn_test.go
+      - main.go
+      - kro
+      - schemas
+      - example
+      - go.mod
+      - LICENSE
+    supporting_sources:
+      - function-kro-kro
+    legacy_exclusions:
+      - examples requiring Claims or claim references
+      - examples requiring deprecated v1 XRD or legacy v1 XR semantics
   - id: function-go-templating
     repository: crossplane-contrib/function-go-templating
     kind: function
@@ -223,6 +246,16 @@ historical_design_sources:
       - general feature inventory
 
 supporting_sources:
+  - id: function-kro-kro
+    repository: kubernetes-sigs/kro
+    kind: resource-graph-orchestrator-documentation
+    authority: supporting
+    version_policy: exact-version-from-selected-function-kro-go-mod
+    agent: okf-function-kro-kro-researcher
+    paths:
+      - website/docs
+      - LICENSE
+    usage: version-matched KRO ResourceGraphDefinition terminology and documented semantics; function-kro source remains authoritative for exposed behavior
   - id: crd-catalog
     repository: CustomResourceDefinition/catalog
     kind: community-crd-schema-catalog

--- a/.codex/agents/okf-function-kro-kro-researcher.toml
+++ b/.codex/agents/okf-function-kro-kro-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-kro-kro-researcher"
+description = "Read-only supporting researcher for the exact KRO version used by the selected function-kro release."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-kro-kro-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-function-kro-researcher.toml
+++ b/.codex/agents/okf-function-kro-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-kro-researcher"
+description = "Read-only user-facing researcher dedicated to crossplane-contrib/function-kro."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-kro-researcher/AGENT.md` as the canonical role instructions."

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -5,6 +5,41 @@ title: Crossplane catalog claim ledger
 
 # Scope
 
+## function-kro v0.3.0 preview
+
+The user explicitly selected function-kro `v0.3.0`, a GitHub prerelease, at
+`a0b4c088bd950cb407901d01ee29263e6d54d639`. Its `go.mod` selects
+`github.com/kubernetes-sigs/kro v0.9.2`; the annotated KRO tag resolves to
+`22f5645777c86ebd40b6143f248549f1dbe2923f`, whose `website/docs` provide the
+version-matched supporting documentation. Researched 2026-08-21. Claims,
+claim references, deprecated XRD v1, and legacy v1 XR semantics were excluded.
+No source text or examples were copied or adapted.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| functions/function-kro/package | Package metadata declares a Crossplane Function named `function-kro`; the README places it in a Composition pipeline with a `ResourceGraph` input. | API and documented-guidance | primary | direct | Package maturity is Not stated by selected sources; explicit preview selection is source scope, not a maturity label. [metadata](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/crossplane.yaml#L2-L6), [pipeline](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/README.md#L20-L65) |
+| functions/function-kro/package | The selected preview directly depends on KRO v0.9.2; KRO semantics are sourced only from that tag's peeled commit. | API | primary and supporting | direct | Not stated by selected sources; [function dependency](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/go.mod#L5-L14), [version-matched KRO docs](https://github.com/kubernetes-sigs/kro/tree/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs) |
+| functions/function-kro/input | `ResourceGraph` is a non-installed KRM-like Function input at `kro.fn.crossplane.io/v1alpha1`; its optional fields are `status` and `resources`. | API | primary | direct | Alpha, from the served `v1alpha1` input API. [type](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/input/v1alpha1/input.go#L1-L30) |
+| functions/function-kro/input | Each resource has an ID and exactly one of `template` or `externalRef`; the schema also exposes `forEach`, `includeWhen`, and `readyWhen`. | API | primary | direct | Alpha input API. [packaged schema](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/input/kro.fn.crossplane.io_resourcegraphs.yaml#L41-L203) |
+| functions/function-kro/input | `${...}` expressions are CEL; whole-field expressions preserve their result type while embedded string expressions require strings. | documented-guidance | supporting | direct | Pattern is Alpha because it requires the function's Alpha input API. [KRO v0.9.2 CEL syntax](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/03-cel-expressions.md#L34-L114) |
+| functions/function-kro/graph-evaluation | The function requests schemas for the XR and graph GVKs, uses `required_schemas` when advertised, otherwise requests CRDs, and waits without a fatal result while schemas are unavailable. | behavior | primary | direct | Alpha, inherited from the required ResourceGraph input. [request path](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L81-L102), [schema paths](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L277-L375) |
+| functions/function-kro/graph-evaluation | CEL references infer graph dependencies; the function evaluates runtime nodes topologically and defers resources whose expression data is pending. | behavior and documented-guidance | primary and supporting | corroborated | Alpha, inherited from the required ResourceGraph input. [KRO dependency semantics](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/04-dependencies-ordering.md#L5-L43), [desired evaluation](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L614-L689) |
+| functions/function-kro/graph-evaluation | External references are read-only and excluded from desired output; name and selector modes are mutually exclusive. | behavior and API | primary and supporting | corroborated | Alpha, inherited from the required ResourceGraph input. [function behavior](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L117-L173), [KRO v0.9.2 guidance](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/02-resource-definitions/05-external-references.md#L5-L89) |
+| functions/function-kro/graph-evaluation | Single desired resources use their node ID; collection members use `{id}-{metadata.name}`. `readyWhen` sets explicit readiness; absent `readyWhen`, readiness remains unspecified for later functions. | behavior | primary | direct | Alpha, inherited from the required ResourceGraph input. [desired identity and readiness](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L651-L685) |
+| functions/function-kro/graph-evaluation | Desired XR output contains only resolved status paths declared by the ResourceGraph, limiting SSA ownership. | behavior | primary | direct | Alpha, inherited from the required ResourceGraph input. [status projection](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L692-L720) |
+
+### Limitations and source boundaries
+
+- The selected sources do not provide an immutable package image reference or
+  a package-installation command.
+- KRO controller installation, generated CRDs, GraphRevisions, permissions,
+  and controller lifecycle are not transferred to function-kro.
+- The KRO upstream `kro.run/v1alpha1` API is Alpha, but that state is not used
+  to label the function package. The function's own `kro.fn.crossplane.io/v1alpha1`
+  input independently establishes the Alpha ceiling for input-dependent patterns.
+- Both repositories are Apache-2.0 licensed; this catalog summarizes and cites
+  without copying source text or examples.
+
 ## Custom-resource gate CRD cache schema stripping
 
 Selected crossplane-runtime `v2.4.0` at

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -149,6 +149,20 @@ sources:
     commit: 311ca76bbd30f86e196438771062091a39e39e0d
     selected_by: PR #906 merge containment base for real-time composition project history
     resolved_at: 2026-07-16
+  function-kro:
+    repository: crossplane-contrib/function-kro
+    tag: v0.3.0
+    commit: a0b4c088bd950cb407901d01ee29263e6d54d639
+    release_status: prerelease
+    selected_by: user-approved preview revision
+    resolved_at: 2026-08-21
+  function-kro-kro:
+    repository: kubernetes-sigs/kro
+    tag: v0.9.2
+    commit: 22f5645777c86ebd40b6143f248549f1dbe2923f
+    source_path: website/docs
+    selected_by: function-kro v0.3.0 go.mod
+    resolved_at: 2026-08-21
   function-go-templating:
     repository: crossplane-contrib/function-go-templating
     tag: v0.12.2

--- a/.pi/agents/okf-function-kro-kro-researcher.md
+++ b/.pi/agents/okf-function-kro-kro-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-kro-kro-researcher
+description: Read-only supporting researcher for the exact KRO version used by the selected function-kro release.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-kro-kro-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-function-kro-researcher.md
+++ b/.pi/agents/okf-function-kro-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-kro-researcher
+description: Read-only user-facing researcher dedicated to crossplane-contrib/function-kro.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-kro-researcher/AGENT.md` as the canonical role instructions.

--- a/catalog/functions/function-kro/graph-evaluation.md
+++ b/catalog/functions/function-kro/graph-evaluation.md
@@ -1,0 +1,125 @@
+---
+type: Crossplane Function
+title: function-kro graph evaluation
+description: Build a schema-aware graph, evaluate desired resources topologically, preserve stable identities, report readiness, and project declared XR status.
+resource: https://github.com/crossplane-contrib/function-kro
+tags: [crossplane, function, kro, graph, desired-state, readiness, status, alpha, preview]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T22:10:49Z" }
+sources:
+  - id: schema-request-flow
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L81-L116'
+    title: Schema request and graph construction flow
+  - id: schema-capability-paths
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L277-L375'
+    title: Required-schema and CRD fallback paths
+  - id: external-reference-flow
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L117-L173'
+    title: External-reference required-resource flow
+  - id: desired-evaluation
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L614-L689'
+    title: Desired-resource evaluation, identity, and readiness
+  - id: status-projection
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L692-L720'
+    title: Minimal desired XR status projection
+  - id: fatal-results
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L62-L79'
+    title: Input and observed-XR fatal results
+  - id: kro-dependencies
+    resource: 'https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/04-dependencies-ordering.md#L5-L43'
+    title: KRO v0.9.2 dependency inference
+  - id: kro-external-references
+    resource: 'https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/02-resource-definitions/05-external-references.md#L5-L89'
+    title: KRO v0.9.2 external-reference semantics
+source_repository: crossplane-contrib/function-kro
+source_tag: v0.3.0
+source_commit: a0b4c088bd950cb407901d01ee29263e6d54d639
+source_paths: [fn.go]
+supporting_sources:
+  - repository: kubernetes-sigs/kro
+    tag: v0.9.2
+    commit: 22f5645777c86ebd40b6143f248549f1dbe2923f
+    paths: [website/docs/docs/concepts/rgd]
+release_status: prerelease
+selection_basis: User-approved preview revision
+feature_state: Alpha
+feature_state_basis: This behavior requires the kro.fn.crossplane.io/v1alpha1 ResourceGraph input.
+---
+
+# Behavior
+
+On each invocation, function-kro:
+
+1. Reads the Alpha [`ResourceGraph` input](input.md) and observed XR.
+2. Collects the XR and graph resource GVKs and requests their schemas.
+3. Builds the resource graph and supplies external and composed observed state.
+4. Evaluates runtime nodes in topological order into desired composed resources.
+5. Returns the accumulated desired resources and only declared, resolved XR
+   status paths.[^schema-request-flow][^desired-evaluation][^status-projection]
+
+This behavior is **Alpha** because it requires the function's `v1alpha1` input.
+It does not assign Alpha maturity to the package itself.
+
+# Schema acquisition
+
+When Crossplane advertises `required_schemas`, the function requests schemas for
+the XR and every graph GVK. The selected source identifies this as the Crossplane
+2.2-and-later path. Otherwise, it requests matching CRDs as required resources.[^schema-capability-paths]
+
+Schema acquisition can require multiple function invocations. While required
+schemas are unavailable, the function returns requirements without a fatal
+result and waits for Crossplane to call it again.[^schema-request-flow]
+
+# Dependency and desired-state evaluation
+
+The matching KRO `v0.9.2` documentation defines CEL references as dependency
+edges and describes topological ordering.[^kro-dependencies] Function-kro's
+runtime walks graph nodes in that order. It excludes read-only external
+references, resources whose `includeWhen` evaluates false, and resources whose
+expression data is still pending.[^desired-evaluation]
+
+Desired objects come from evaluated templates rather than observed objects, so
+provider-defaulted observed fields are not copied into the function's desired
+SSA ownership.[^desired-evaluation]
+
+# Identity and readiness
+
+A single resource uses its graph node ID as the Crossplane desired-resource
+name. A `forEach` collection member uses `{id}-{metadata.name}`, avoiding list
+position as its cross-reconcile identity.[^desired-evaluation]
+
+When `readyWhen` is present, the function reports explicit ready or not-ready
+state from its evaluation. Without `readyWhen`, it leaves readiness unspecified
+so a later pipeline function such as function-auto-ready can decide it.[^desired-evaluation]
+
+# External references
+
+The function turns external references into Crossplane required-resource
+selectors, supplies returned objects to the graph runtime, and never includes
+them in desired composed output.[^external-reference-flow][^desired-evaluation]
+The version-matched KRO documentation defines them as read-only references and
+distinguishes name from selector modes.[^kro-external-references]
+
+# XR status ownership
+
+The desired XR contains only ResourceGraph-declared status paths whose CEL
+values have resolved. This bounds the function's desired XR status ownership;
+unresolved paths are omitted until a later invocation.[^status-projection]
+
+# Errors and limitations
+
+Invalid input and observed-XR retrieval or decoding errors become fatal Function
+results.[^fatal-results] Graph construction, runtime evaluation, and desired
+resource conversion errors also stop that invocation; pending schemas and pending
+expression data are deferrals rather than equivalent fatal errors.
+
+KRO controller installation, generated CRDs, GraphRevisions, controller
+permissions, and standalone reconciliation behavior are outside this concept.
+
+[^schema-request-flow]: [Schema request and graph construction flow](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L81-L116)
+[^schema-capability-paths]: [Required-schema and CRD fallback paths](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L277-L375)
+[^external-reference-flow]: [External-reference required-resource flow](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L117-L173)
+[^desired-evaluation]: [Desired-resource evaluation, identity, and readiness](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L614-L689)
+[^status-projection]: [Minimal desired XR status projection](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L692-L720)
+[^fatal-results]: [Input and observed-XR fatal results](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/fn.go#L62-L79)
+[^kro-dependencies]: [KRO v0.9.2 dependency inference](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/04-dependencies-ordering.md#L5-L43)
+[^kro-external-references]: [KRO v0.9.2 external-reference semantics](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/02-resource-definitions/05-external-references.md#L5-L89)

--- a/catalog/functions/function-kro/index.md
+++ b/catalog/functions/function-kro/index.md
@@ -1,0 +1,5 @@
+# function-kro v0.3.0 preview
+
+* [Function package](package.md) - Place the preview Function in a Composition pipeline and understand its version-matched KRO dependency.
+* [ResourceGraph input](input.md) - Author the Alpha templates, external references, collections, conditions, readiness, status, and CEL expressions.
+* [Graph evaluation](graph-evaluation.md) - Understand schema acquisition, dependency evaluation, desired-resource identity, readiness, and XR status ownership.

--- a/catalog/functions/function-kro/input.md
+++ b/catalog/functions/function-kro/input.md
@@ -1,0 +1,98 @@
+---
+type: Crossplane Function Input
+title: function-kro ResourceGraph input
+description: Author Alpha ResourceGraph inputs with templates, external references, collections, conditions, readiness, status, and CEL expressions.
+resource: https://github.com/crossplane-contrib/function-kro
+tags: [crossplane, function, kro, resource-graph, cel, alpha, preview]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T22:10:49Z" }
+sources:
+  - id: input-type
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/input/v1alpha1/input.go#L1-L30'
+    title: ResourceGraph input type
+  - id: packaged-schema
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/input/kro.fn.crossplane.io_resourcegraphs.yaml#L41-L210'
+    title: Packaged ResourceGraph schema
+  - id: readme-expressions
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/README.md#L20-L65'
+    title: ResourceGraph and CEL example
+  - id: kro-resource-basics
+    resource: 'https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md#L10-L81'
+    title: KRO v0.9.2 resource basics
+  - id: kro-cel-expressions
+    resource: 'https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/03-cel-expressions.md#L34-L114'
+    title: KRO v0.9.2 CEL expressions
+source_repository: crossplane-contrib/function-kro
+source_tag: v0.3.0
+source_commit: a0b4c088bd950cb407901d01ee29263e6d54d639
+source_paths:
+  - input/v1alpha1/input.go
+  - package/input/kro.fn.crossplane.io_resourcegraphs.yaml
+  - README.md
+supporting_sources:
+  - repository: kubernetes-sigs/kro
+    tag: v0.9.2
+    commit: 22f5645777c86ebd40b6143f248549f1dbe2923f
+    paths: [website/docs/docs/concepts/rgd]
+release_status: prerelease
+selection_basis: User-approved preview revision
+feature_state: Alpha
+feature_state_basis: The Function input API is served as kro.fn.crossplane.io/v1alpha1.
+---
+
+# Overview
+
+The function accepts a KRM-like `kro.fn.crossplane.io/v1alpha1` object with
+kind `ResourceGraph`. Its generated CRD describes the input schema but is not
+installed as a Kubernetes custom resource.[^input-type]
+
+This input API is **Alpha** because its served version is `v1alpha1`. That
+ceiling applies to the input and patterns that require it, not to the
+[function package](package.md).
+
+# Schema
+
+The top-level `status` and `resources` fields are optional. `status` is an
+arbitrary object of CEL projections; `resources` is an array of KRO resource
+definitions.[^input-type][^packaged-schema]
+
+| Resource field | Contract in the selected preview |
+| --- | --- |
+| `id` | Required identifier used by CEL references. |
+| `template` | Kubernetes manifest to create; exactly one of `template` or `externalRef` is required. |
+| `externalRef` | Existing resource to read; requires `apiVersion`, `kind`, and metadata with exactly one of `name` or `selector`. |
+| `forEach` | Array of single-entry iterator maps; each expression produces an array and multiple entries form a Cartesian product. |
+| `includeWhen` | Boolean CEL expressions; all must be true for inclusion. |
+| `readyWhen` | Boolean CEL expressions used to determine readiness. |
+
+These constraints come from the packaged schema at the selected function
+commit.[^packaged-schema]
+
+# CEL expressions
+
+Resource templates and status use `${...}` CEL expressions, including
+references to the XR through `schema` and to other graph resources by ID.[^readme-expressions]
+The version-matched KRO documentation distinguishes whole-field expressions,
+which preserve their CEL result type, from expressions embedded in strings,
+which must produce strings.[^kro-cel-expressions]
+
+KRO's documentation also describes resource IDs, Kubernetes templates, and
+schema-backed checking.[^kro-resource-basics] Function-kro's packaged schema and
+runtime remain authoritative for what this preview actually accepts and emits.
+
+# External-reference namespace boundary
+
+For a named reference, an omitted namespace defaults to the XR namespace. For
+a selector collection, an empty namespace means an all-namespace list.[^packaged-schema]
+The latter therefore has a wider read scope than a namespace-constrained selector.
+
+# Relationships
+
+See [graph evaluation](graph-evaluation.md) for how the function obtains schemas,
+evaluates these fields, names desired resources, reports readiness, and projects
+status.
+
+[^input-type]: [ResourceGraph input type](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/input/v1alpha1/input.go#L1-L30)
+[^packaged-schema]: [Packaged ResourceGraph schema](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/input/kro.fn.crossplane.io_resourcegraphs.yaml#L41-L210)
+[^readme-expressions]: [ResourceGraph and CEL example](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/README.md#L20-L65)
+[^kro-resource-basics]: [KRO v0.9.2 resource basics](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/02-resource-definitions/01-resource-basics.md#L10-L81)
+[^kro-cel-expressions]: [KRO v0.9.2 CEL expressions](https://github.com/kubernetes-sigs/kro/blob/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs/docs/concepts/rgd/03-cel-expressions.md#L34-L114)

--- a/catalog/functions/function-kro/package.md
+++ b/catalog/functions/function-kro/package.md
@@ -1,0 +1,71 @@
+---
+type: Crossplane Function
+title: function-kro
+description: Run KRO-style YAML and CEL resource graphs as a Crossplane Composition pipeline step.
+resource: https://github.com/crossplane-contrib/function-kro
+tags: [crossplane, function, composition, kro, cel, preview]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T22:10:49Z" }
+sources:
+  - id: package-metadata
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/crossplane.yaml#L2-L6'
+    title: Function package metadata
+  - id: pipeline-usage
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/README.md#L11-L65'
+    title: Embedded KRO and ResourceGraph pipeline usage
+  - id: selected-dependencies
+    resource: 'https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/go.mod#L5-L14'
+    title: Selected preview dependencies
+  - id: kro-versioned-docs
+    resource: 'https://github.com/kubernetes-sigs/kro/tree/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs'
+    title: KRO v0.9.2 documentation tree
+source_repository: crossplane-contrib/function-kro
+source_tag: v0.3.0
+source_commit: a0b4c088bd950cb407901d01ee29263e6d54d639
+source_paths: [README.md, package/crossplane.yaml, go.mod]
+release_status: prerelease
+selection_basis: User-approved preview revision
+feature_state: Not stated by selected sources
+---
+
+# Overview
+
+`function-kro` is packaged as a Crossplane `Function` named `function-kro`.
+The selected source shows it referenced from a Composition pipeline step with a
+[`ResourceGraph` input](input.md).[^package-metadata][^pipeline-usage]
+
+This concept describes the user-approved `v0.3.0` preview at
+`a0b4c088bd950cb407901d01ee29263e6d54d639`. The GitHub release is a
+prerelease; that source-selection status does not establish package maturity.
+Package feature state is **Not stated by selected sources**.
+
+# KRO dependency
+
+The selected preview directly depends on `github.com/kubernetes-sigs/kro`
+`v0.9.2`.[^selected-dependencies] KRO terminology and documented expression
+semantics in this catalog use only the matching documentation at commit
+`22f5645777c86ebd40b6143f248549f1dbe2923f`.[^kro-versioned-docs]
+
+KRO is embedded as a dependency; composition authors do not need to install the
+standalone KRO controller for this function's pipeline step.[^pipeline-usage]
+The upstream controller's CRD generation, GraphRevision, permissions, and
+controller lifecycle are therefore not attributed to function-kro.
+
+# Pipeline placement
+
+Place the function in `spec.pipeline` and reference the installed Function
+object by name. The selected README demonstrates the input API
+`kro.fn.crossplane.io/v1alpha1` and kind `ResourceGraph`.[^pipeline-usage]
+
+The selected source does not provide an immutable package image reference or a
+package-installation command, so this catalog does not invent one.
+
+# Relationships
+
+Use [ResourceGraph input](input.md) for the authoring schema. See
+[graph evaluation](graph-evaluation.md) for schema acquisition, desired-resource
+identity, readiness, external references, and XR status projection.
+
+[^package-metadata]: [Function package metadata](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/package/crossplane.yaml#L2-L6)
+[^pipeline-usage]: [Embedded KRO and ResourceGraph pipeline usage](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/README.md#L11-L65)
+[^selected-dependencies]: [Selected preview dependencies](https://github.com/crossplane-contrib/function-kro/blob/a0b4c088bd950cb407901d01ee29263e6d54d639/go.mod#L5-L14)
+[^kro-versioned-docs]: [KRO v0.9.2 documentation tree](https://github.com/kubernetes-sigs/kro/tree/22f5645777c86ebd40b6143f248549f1dbe2923f/website/docs)

--- a/catalog/functions/index.md
+++ b/catalog/functions/index.md
@@ -12,6 +12,7 @@
 * [function-go-templating](function-go-templating/index.md) - Render desired resources from Go templates in a composition pipeline.
 * [function-sequencer](function-sequencer/index.md) - Gate dependent desired resources with declared readiness sequencing and XR Events.
 * [function-auto-ready](function-auto-ready/index.md) - Determine desired composed-resource readiness from observed resources.
+* [function-kro](function-kro/index.md) - Evaluate KRO-style YAML and CEL resource graphs in a Composition pipeline.
 * [EnvironmentConfig, Go templating, and readiness pipeline](environment-config-pipeline.md) - Order the three functions by their context and desired-resource dependencies.
 
 # Operation Functions

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,5 +1,8 @@
 # Catalog Update Log
 
+## 2026-08-21
+* **Creation**: Added a user-selected function-kro v0.3.0 preview reference for the package, Alpha ResourceGraph input, and graph evaluation behavior, backed by the exact KRO v0.9.2 documentation selected in go.mod.
+
 ## 2026-08-20
 * **Migration**: Migrated the catalog to OKF v0.2 by replacing legacy timestamps with generation metadata and moving numbered citation lists into frontmatter provenance with keyed claim footnotes.
 


### PR DESCRIPTION
## Summary

- add release-pinned function-kro v0.3.0 preview knowledge for the package, Alpha ResourceGraph input, and graph evaluation behavior
- resolve the embedded KRO dependency to v0.9.2 and use only its commit-pinned website documentation as supporting evidence
- add dedicated function-kro and KRO dependency researcher profiles with matching Codex and Pi adapters
- update source locks, claim ledger, function index, and catalog log

## Evidence scope

- function-kro v0.3.0: a0b4c088bd950cb407901d01ee29263e6d54d639 (user-approved prerelease)
- KRO v0.9.2: 22f5645777c86ebd40b6143f248549f1dbe2923f (peeled annotated tag)
- package maturity: Not stated by selected sources
- ResourceGraph input and dependent graph behavior: Alpha from kro.fn.crossplane.io/v1alpha1

## Validation

- okf validate catalog/: conformant, 0 errors, 0 warnings
- custom frontmatter, source-footnote, generated metadata, immutable citation, and internal-link checks passed
- mise run lint: passed
- MCP unit tests: 31 passed
- okf-reviewer: APPROVED