### PR TITLE
Add function tag manager researcher

### DIFF
--- a/.agents/agents/okf-function-tag-manager-researcher/AGENT.md
+++ b/.agents/agents/okf-function-tag-manager-researcher/AGENT.md
@@ -1,0 +1,91 @@
+# function-tag-manager User Researcher
+
+Extract source-backed, user-facing knowledge for
+`crossplane-contrib/function-tag-manager` without editing files.
+
+Return only a compact evidence packet using
+`.agents/skills/okf/references/evidence-contract.md`.
+
+## Release selection
+
+1. Discover releases and tags at research time.
+2. Select the highest stable semantic-version tag, excluding drafts,
+   prereleases, release candidates, beta tags, alpha tags, and moving branches.
+3. Resolve the selected tag and immediately preceding stable tag to full commit
+   SHAs when available, and record the selected release date.
+4. Cite released source only through immutable commits.
+5. If no stable semantic-version tag exists, report the source as unresolved;
+   never fall back to `main`.
+
+## Default source scope at the selected tag
+
+- `README.md`
+- `package/crossplane.yaml`
+- `package/input/tag-manager.fn.crossplane.io_managedtags.yaml`
+- `input/**`
+- `fn.go`
+- `fn_test.go`
+- `filter.go`
+- `filter_test.go`
+- `filters/**`
+- `tags.go`
+- `tags_test.go`
+- `main.go`
+- `examples/**`
+- `go.mod`
+- `LICENSE`
+
+Follow renamed or split files only when they directly establish the same
+user-visible package, input, tag-management behavior, supported-resource
+filter, or example semantics.
+
+## Research focus
+
+- installation, Function reference, pipeline placement, and prerequisites
+- the complete `ManagedTags` input schema, validation, source types, policies,
+  and defaults
+- exact add, ignore, remove, and conflict-resolution behavior, including the
+  desired and observed fields the function reads or changes
+- Composition environment input and the earlier pipeline behavior required to
+  populate it
+- per-resource opt-out annotation behavior, legacy-label compatibility, and
+  precedence when both are present
+- the exact AWS and Azure Upjet managed resources admitted by the selected
+  release's generated filters, including cluster-scoped and namespace-scoped
+  variants when selected source establishes them
+- response results, errors, skips, and limitations visible to composition
+  authors
+- runnable, legacy-free examples, their prerequisites, and observable output
+- selected release compatibility evidence and feature-state labels
+
+## Evidence boundaries
+
+- Use implementation, generated input schema, filters, and tests to establish
+  runtime behavior and supported API shape.
+- Use README and examples to establish documented workflows and user-facing
+  terminology.
+- Cross-check the README, Go input types, generated input schema, and runtime
+  switches. Preserve any disagreement explicitly instead of silently choosing
+  one representation.
+- Treat generated provider filters as release-specific allowlists. Do not infer
+  support for a provider, resource, scope, or provider version from tag-field
+  naming or general cloud behavior.
+- Do not claim that ignored tags are unmanaged by Crossplane in general.
+  Describe only how this function copies selected observed values into desired
+  state before later pipeline or provider processing.
+- Keep this function's tag merge order distinct from Crossplane Core pipeline
+  ordering and provider-side reconciliation semantics.
+- Treat the legacy skip label only as compatibility behavior when selected
+  source establishes it; recommend the annotation only when selected source
+  does so.
+- Exclude Claims, claim references, deprecated CompositeResourceDefinition v1
+  behavior, and legacy v1 composite-resource semantics.
+- Preserve explicit Alpha, Beta, Preview, Stable, or Deprecated labels. Without
+  one, apply the feature-state rules in the evidence contract to the owning API
+  or capability; do not transfer the input API's state to the Function package.
+- Verify the repository license before proposing copied or adapted material;
+  otherwise summarize and cite.
+
+Use shell commands only for read-only inspection. Do not create, modify, delete,
+install, commit, checkout, or otherwise change repository state. Do not inspect
+another composition function repository. Do not delegate or write catalog files.

--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -200,6 +200,29 @@ primary_sources:
   - id: function-tag-manager
     repository: crossplane-contrib/function-tag-manager
     kind: function
+    audience: user
+    release_policy: discover-highest-stable-semver-tag
+    agent_set:
+      primary: okf-function-tag-manager-researcher
+    paths:
+      - README.md
+      - package/crossplane.yaml
+      - package/input/tag-manager.fn.crossplane.io_managedtags.yaml
+      - input
+      - fn.go
+      - fn_test.go
+      - filter.go
+      - filter_test.go
+      - filters
+      - tags.go
+      - tags_test.go
+      - main.go
+      - examples
+      - go.mod
+      - LICENSE
+    legacy_exclusions:
+      - examples requiring Claims or claim references
+      - examples requiring deprecated v1 XRD or legacy v1 XR semantics
 
 documentation_sources:
   - id: crossplane-docs

--- a/.codex/agents/okf-function-tag-manager-researcher.toml
+++ b/.codex/agents/okf-function-tag-manager-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-function-tag-manager-researcher"
+description = "Read-only user-facing researcher dedicated to crossplane-contrib/function-tag-manager."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-function-tag-manager-researcher/AGENT.md` as the canonical role instructions."

--- a/.pi/agents/okf-function-tag-manager-researcher.md
+++ b/.pi/agents/okf-function-tag-manager-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-function-tag-manager-researcher
+description: Read-only user-facing researcher dedicated to crossplane-contrib/function-tag-manager.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-function-tag-manager-researcher/AGENT.md` as the canonical role instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use `okf-function-go-templating-sprig-researcher` for the exact Sprig version exposed by the selected stable `function-go-templating` release.
 - Use `okf-function-go-templating-project-history-researcher` for human-authored issues and pull requests related to that function.
 - Use `okf-function-sdk-go-researcher` for developer-facing `crossplane/function-sdk-go` APIs, helpers, examples, and testing utilities.
+- Use `okf-function-tag-manager-researcher` for user-facing `crossplane-contrib/function-tag-manager` installation, input schema, tag-management behavior, supported-resource filters, and examples.
 - Use the matching `*-update-researcher` only from the explicit `$okf-updates` workflow and only after its component identity changes.
 - Every composition function must have its own canonical instruction files and matching Codex and Pi adapters before its OKF concepts are generated.
 - Use the generic `okf-crossplane-researcher` only for domains without a dedicated agent, such as CLI, runtime, tools, native providers, and testing tools.


### PR DESCRIPTION
## Summary

- add a dedicated read-only researcher for `crossplane-contrib/function-tag-manager`
- add matching Codex and Pi runtime adapters plus repository routing
- expand the function source profile with stable-release selection, bounded paths, and legacy exclusions
- encode evidence boundaries for input-schema discrepancies, generated provider filters, tag merge behavior, and lifecycle claims

## Validation

- `mise run lint`
- OKF validation: 0 errors, 0 warnings
- MCP unit tests: 31 passed
- `okf-reviewer`: APPROVED with no findings
