### PR TITLE
Add provider development SDK knowledge

### DIFF
--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -36,6 +36,37 @@ primary_sources:
   - id: crossplane-tools
     repository: crossplane/crossplane-tools
     kind: development-tools
+  - id: provider-template
+    repository: crossplane/provider-template
+    kind: provider-development-template
+    audience: developer
+    revision_policy: pin-current-main-commit-at-research-time
+    agent: okf-crossplane-researcher
+    paths:
+      - README.md
+      - PROVIDER_CHECKLIST.md
+      - .gitmodules
+      - Makefile
+      - go.mod
+      - apis
+      - internal/controller
+      - cmd/provider
+      - hack/helpers
+      - examples
+      - package
+      - cluster/local/integration_tests.sh
+      - LICENSE
+    version_dependencies:
+      crossplane-runtime: exact-version-from-go-mod
+      crossplane-build: exact-submodule-commit
+      crossplane-tools: exact-version-from-go-mod
+    supporting_sources:
+      - crossplane-build
+      - crossplane-tools
+    legacy_exclusions:
+      - Claims and claim references
+      - deprecated XRD v1 and legacy v1 XR semantics
+      - deprecated generator modes not selected by the template's modern APIs
   - id: function-sdk-go
     repository: crossplane/function-sdk-go
     kind: function-sdk
@@ -271,6 +302,19 @@ historical_design_sources:
       - general feature inventory
 
 supporting_sources:
+  - id: crossplane-build
+    repository: crossplane/build
+    kind: shared-build-tooling
+    authority: supporting
+    version_policy: exact-submodule-commit-from-selected-provider-template
+    paths:
+      - makelib/common.mk
+      - makelib/golang.mk
+      - makelib/k8s_tools.mk
+      - makelib/imagelight.mk
+      - makelib/xpkg.mk
+      - LICENSE
+    usage: version-matched build, test, image, and xpkg behavior invoked by provider-template
   - id: function-kro-kro
     repository: kubernetes-sigs/kro
     kind: resource-graph-orchestrator-documentation

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -5,6 +5,61 @@ title: Crossplane catalog claim ledger
 
 # Scope
 
+## Provider development SDK from provider-template
+
+Selected the user-requested `crossplane/provider-template` `main` snapshot at
+`a74b386da0ec848036e16ff0a207c5a16bc9827f`. This workflow pins that immutable
+snapshot rather than assigning it a semantic-version release identity. Its
+`go.mod` selects Crossplane and crossplane-runtime `v2.3.3`; the
+runtime tag resolves to `fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827`.
+Version-matched supporting sources are crossplane/build at
+`b964dbe0ff0856a762f1a06fe554c647d22af7f0` and crossplane-tools at
+`60e57f817ad1f80dcf052a940cf923fde56fab1f`. Current orientation uses
+Crossplane `v2.4.0` and docs series `v2.4` at
+`f51137d2f8e92a167bb580be528c78b879ed406d`. Researched 2026-08-21.
+Claims, deprecated XRD v1, legacy v1 XR semantics, Core design documents, and
+project history were excluded. No source text or examples were copied or
+adapted.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| sdk/provider-development/start-here | Official v2.4 documentation assigns providers authentication, external API calls, Kubernetes APIs, and controller logic; provider-template is an official minimal hand-written-provider starting point. | documented-guidance | official-documentation and primary | corroborated | Not stated by selected sources; [provider responsibilities](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L7-L29), [template purpose](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L1-L10) |
+| sdk/provider-development/start-here | The selected template snapshot selects Crossplane APIs and crossplane-runtime v2.3.3; a stable dependency tag does not establish template maturity. | API | primary | direct | Not stated by selected sources; [selected dependencies](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/go.mod#L1-L19) |
+| sdk/provider-development/start-here | The template workflow initializes the build submodule, renames the provider, adds an API type, replaces sample implementations, registers controllers, then runs reviewable and build targets. | documented-guidance | primary | direct | Not stated by selected sources; [workflow](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L12-L32) |
+| sdk/provider-development/managed-resource-apis | The sample `MyType` is a namespaced modern managed resource with `ManagedResourceSpec`, `forProvider`, `ManagedResourceStatus`, and `atProvider`. | API | primary | direct | Alpha because the owning sample API is `sample.template.crossplane.io/v1alpha1`; [type](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/mytype_types.go#L29-L73), [version](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/groupversion_info.go#L17-L32) |
+| sdk/provider-development/managed-resource-apis | Runtime `ModernManaged` adds a local connection-secret target and typed ProviderConfig reference to the base managed contract; `LegacyManaged` is explicitly deprecated for new namespace-scoped MRs. | API | primary | direct | Go SDK maturity is Not stated; the legacy sub-surface is explicitly Deprecated. [interfaces](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/interfaces.go#L192-L225) |
+| sdk/provider-development/managed-resource-apis | Authored API types and generator directives are source inputs; deepcopy/methodset files and packaged CRDs are generated outputs. | behavior | primary and supporting | corroborated | Not stated by selected sources; [generation directives](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/generate.go#L20-L27), [angryjet methodsets](https://github.com/crossplane/crossplane-tools/blob/60e57f817ad1f80dcf052a940cf923fde56fab1f/cmd/angryjet/main.go#L66-L118) |
+| sdk/provider-development/provider-configuration | The Alpha template API defines namespaced ProviderConfig, cluster-scoped ClusterProviderConfig, and namespaced ProviderConfigUsage with typed references. | API | primary | direct | Alpha from `template.crossplane.io/v1alpha1`; [types](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/v1alpha1/types.go#L31-L110) |
+| sdk/provider-development/provider-configuration | The template declares None, Secret, InjectedIdentity, Environment, and Filesystem sources, but runtime's common extractor has no generic InjectedIdentity handler. | API and limitation | primary | corroborated | Alpha for the template credential API; helper maturity Not stated. [template credentials](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/v1alpha1/types.go#L22-L34), [runtime extractor](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L60-L113) |
+| sdk/provider-development/provider-configuration | The connector tracks typed ProviderConfig usage before fetching the selected namespaced or cluster-scoped config, then extracts credentials and constructs the external service client. | behavior | primary | corroborated | Template API Alpha; runtime behavior maturity Not stated. [template connector](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L120-L161), [usage tracker contract](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L157-L207) |
+| sdk/provider-development/managed-reconciler | Typed external clients must be non-blocking and idempotent; Observe must not mutate the external resource, and Create, Update, Delete, and Disconnect have explicit lifecycle roles. | API | primary | direct | Not stated by selected sources; these are unlabelled Go SDK contracts. [external client](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L274-L415) |
+| sdk/provider-development/managed-reconciler | The reconciler initializes and resolves references before connecting and observing; reference resolution is skipped during deletion, and connection/observation failures produce events and conditions. | behavior | primary | direct | Not stated by selected sources; [ordering](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L1083-L1196) |
+| sdk/provider-development/managed-reconciler | The template wires a typed connector, usage tracker, safe-start gate, management-policy option, desired-state filter, metrics, poll interval, and rate limiter, but its external service behavior is explicitly simulated and must be replaced. | behavior and illustrative-pattern | primary | direct | Runtime/template workflow maturity Not stated; sample API Alpha. [setup](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L51-L109), [simulated client](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L172-L254) |
+| sdk/provider-development/managed-reconciler | Runtime supplies fake modern/legacy managed resources, ProviderConfigs, typed usages, and a configurable controller-runtime mock client; the template's `TestObserve` table has no cases. | API and limitation | primary | direct | Not stated by selected sources; [runtime fakes](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/fake/mocks.go#L343-L425), [mock client](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/test/fake.go#L270-L318), [empty template test table](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype_test.go#L39-L75) |
+| sdk/provider-development/generate-test-package | The template gitlink pins crossplane/build at b964dbe0; that build machinery defines reviewable as generation, lint, and test, while generation runs go generate and go mod tidy, tests use go test with coverage, and build compiles configured static packages. | behavior | primary and supporting | corroborated | Not stated by selected sources; [immutable template tree and build gitlink](https://api.github.com/repos/crossplane/provider-template/git/trees/a74b386da0ec848036e16ff0a207c5a16bc9827f?recursive=1), [reviewable](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/common.mk#L427-L446), [Go targets](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/golang.mk#L101-L169) |
+| sdk/provider-development/generate-test-package | The template builds a Provider runtime image and an xpkg whose metadata declares a Provider and safe-start capability; the selected xpkg machinery embeds the runtime image. | behavior and API | primary and supporting | corroborated | Workflow/package maturity Not stated; [template targets](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/Makefile#L6-L45), [xpkg build](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/xpkg.mk#L67-L89), [metadata](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/package/crossplane.yaml#L1-L13) |
+| sdk/provider-development/generate-test-package | Official v2.4 docs install provider packages from an OCI registry through a Provider object and support digest references for deterministic installs; the page explicitly excludes provider-building instructions. | documented-guidance | official-documentation | direct | Not stated by selected sources; [installation](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L33-L75), [digest](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L110-L136) |
+
+### Limitations and source boundaries
+
+- `provider-template` is an official primary source, while its `MyType`,
+  credentials examples, and simulated external service are illustrative
+  scaffolding that the repository directs authors to replace.
+- The selected template snapshot uses Crossplane/runtime v2.3.3 while current
+  stable Crossplane orientation is v2.4.0.
+- The older contributing provider-development guide states a runtime v0.9.0
+  target and cluster-scoped-only assumptions. Those statements were excluded
+  from current SDK guidance; current template and version-matched runtime
+  implementation establish the selected behavior.
+- The template README calls ProviderConfig Secret-only, while its types and CRD
+  admit five credential sources. The API/schema are used for shape and the
+  disagreement is preserved.
+- The integration script discovers a chart version dynamically, so it is not
+  evidence for an immutable Crossplane integration-test version.
+- provider-template, crossplane-runtime, crossplane/build, and crossplane-tools
+  are Apache-2.0 licensed. This catalog summarizes and cites without copying or
+  adapting source material.
+
 ## function-kro v0.3.0 preview
 
 The user explicitly selected function-kro `v0.3.0`, a GitHub prerelease, at

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -65,6 +65,42 @@ sources:
     commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
     selected_by: crossplane/v2.3.3
     resolved_at: 2026-07-14
+  crossplane-v2.4.0:
+    repository: crossplane/crossplane
+    tag: v2.4.0
+    commit: 61fa450c0c14a75bf5632872bd4a5b6945ec5a26
+    selected_by: current stable release for provider-development orientation
+    resolved_at: 2026-08-21
+  crossplane-docs-v2.4:
+    repository: crossplane/docs
+    series: v2.4
+    commit: f51137d2f8e92a167bb580be528c78b879ed406d
+    selected_by: crossplane/v2.4.0 provider documentation
+    resolved_at: 2026-08-21
+  provider-template:
+    repository: crossplane/provider-template
+    branch: main
+    commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+    revision: immutable-main-snapshot
+    selected_by: user-requested provider-development SDK starting point
+    resolved_at: 2026-08-21
+  crossplane-runtime-provider-template:
+    repository: crossplane/crossplane-runtime
+    tag: v2.3.3
+    commit: fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827
+    selected_by: provider-template@a74b386da0ec848036e16ff0a207c5a16bc9827f go.mod
+    resolved_at: 2026-08-21
+  crossplane-build-provider-template:
+    repository: crossplane/build
+    commit: b964dbe0ff0856a762f1a06fe554c647d22af7f0
+    selected_by: provider-template@a74b386da0ec848036e16ff0a207c5a16bc9827f build submodule
+    resolved_at: 2026-08-21
+  crossplane-tools-provider-template:
+    repository: crossplane/crossplane-tools
+    version: v0.0.0-20260715161912-60e57f817ad1
+    commit: 60e57f817ad1f80dcf052a940cf923fde56fab1f
+    selected_by: provider-template@a74b386da0ec848036e16ff0a207c5a16bc9827f go.mod
+    resolved_at: 2026-08-21
   crossplane-cli:
     repository: crossplane/cli
     tag: v2.4.0

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,6 +1,7 @@
 # Catalog Update Log
 
 ## 2026-08-21
+* **Creation**: Added a provider-development SDK route from an immutable provider-template snapshot through modern managed-resource APIs, ProviderConfig and credentials, typed reconciliation, generation, testing, and xpkg packaging.
 * **Creation**: Added a user-selected function-kro v0.3.0 preview reference for the package, Alpha ResourceGraph input, and graph evaluation behavior, backed by the exact KRO v0.9.2 documentation selected in go.mod.
 
 ## 2026-08-20

--- a/catalog/sdk/index.md
+++ b/catalog/sdk/index.md
@@ -1,3 +1,4 @@
 # Crossplane SDKs
 
+* [Provider development SDK](provider-development/index.md) - Start from provider-template and implement modern APIs, configuration, reconciliation, tests, and package outputs against pinned sources.
 * [Custom-resource gate CRD cache schema stripping](crd-cache-schema-stripping.md) - Configure the opt-in crossplane-runtime cache transform without hiding data required by other CRD cache consumers.

--- a/catalog/sdk/provider-development/generate-test-package.md
+++ b/catalog/sdk/provider-development/generate-test-package.md
@@ -1,0 +1,128 @@
+---
+type: Crossplane Development Guide
+title: Generate, test, build, and package a provider
+description: Use provider-template's pinned build and generation toolchain to review API output, test controllers, build the runtime image, and produce an xpkg.
+resource: https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/Makefile
+tags: [crossplane, provider-development, sdk, testing, build, xpkg]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:09:30Z" }
+sources:
+  - id: build-submodule-gitlink
+    resource: 'https://api.github.com/repos/crossplane/provider-template/git/trees/a74b386da0ec848036e16ff0a207c5a16bc9827f?recursive=1'
+    title: Immutable provider-template tree containing the build gitlink
+  - id: template-makefile
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/Makefile#L1-L67'
+    title: Template Go, image, xpkg, and integration targets
+  - id: generation-directives
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/generate.go#L20-L27'
+    title: Provider API generation directives
+  - id: reviewable-target
+    resource: 'https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/common.mk#L427-L446'
+    title: Pinned build reviewable target
+  - id: go-targets
+    resource: 'https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/golang.mk#L101-L169'
+    title: Pinned Go generation, test, and build targets
+  - id: xpkg-build
+    resource: 'https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/xpkg.mk#L67-L89'
+    title: Pinned xpkg output and runtime image embedding
+  - id: provider-package-metadata
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/package/crossplane.yaml#L1-L13'
+    title: Template Provider package metadata
+  - id: integration-install
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/cluster/local/integration_tests.sh#L139-L174'
+    title: Template integration package installation and health wait
+  - id: provider-package-installation
+    resource: 'https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L33-L75'
+    title: Crossplane v2.4 Provider package installation
+  - id: digest-installation
+    resource: 'https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L110-L136'
+    title: Crossplane v2.4 registry and digest guidance
+source_repository: crossplane/provider-template
+source_commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+supporting_source_repositories:
+  - repository: crossplane/build
+    commit: b964dbe0ff0856a762f1a06fe554c647d22af7f0
+  - repository: crossplane/docs
+    series: v2.4
+    commit: f51137d2f8e92a167bb580be528c78b879ed406d
+source_paths: [Makefile, apis/generate.go, package/crossplane.yaml, cluster/local/integration_tests.sh]
+feature_state: Not stated by selected sources
+feature_state_basis: Unlabelled build, test, generation, and packaging workflow; individual manifest API versions do not transfer maturity to the workflow.
+---
+
+# Pinned toolchain
+
+The selected template commit pins its shared `crossplane/build` submodule at
+`b964dbe0ff0856a762f1a06fe554c647d22af7f0`. The template Makefile delegates
+normal Go, image, Kubernetes-tool, and xpkg behavior to that submodule.[^build-submodule-gitlink][^template-makefile]
+Keep the submodule initialized and evaluate build behavior against that exact
+revision rather than a moving build branch.
+
+# Generation and review gate
+
+Run:
+
+```shell
+make reviewable
+```
+
+At the selected build revision, `reviewable` is the aggregate generation,
+lint, and test gate.[^reviewable-target] Its Go generation path runs
+`go generate` and `go mod tidy`; the template's API directive regenerates
+deepcopy methods, CRDs, and Crossplane method sets.[^go-targets][^generation-directives]
+The unit-test target runs Go tests with coverage, and the build target compiles
+the configured static package (`cmd/provider` in this template).[^go-targets][^template-makefile]
+
+Review generated changes to `zz_generated*.go` and `package/crds/**` before
+committing. An unexpected generated diff is evidence that an authored API or
+tool version changed; do not hand-edit it away.
+
+# Build outputs
+
+The template configures one Provider runtime image and one xpkg. The selected
+xpkg machinery produces `<name>-<version>.xpkg` and embeds the Provider runtime
+image when the package metadata is a `Provider`.[^template-makefile][^xpkg-build]
+
+The checked-in metadata declares:
+
+- `kind: Provider` in `meta.pkg.crossplane.io/v1alpha1`;
+- the source repository and Apache-2.0 license; and
+- the `safe-start` package capability.[^provider-package-metadata]
+
+That metadata API version does not label the entire Provider implementation or
+build workflow Alpha. Their maturity is **Not stated by selected sources**.
+
+# Local and integration checks
+
+The Makefile offers `run`, `dev`, `dev-clean`, and an integration target.[^template-makefile]
+The selected integration script installs the built xpkg as a Provider and
+waits for a Healthy condition.[^integration-install] It discovers a Crossplane
+chart version dynamically, so the script is not evidence of testing against a
+single immutable Crossplane release. Pin the test environment separately when
+release reproducibility matters.
+
+The template's checked-in managed-resource unit test has no cases; complete
+the controller test matrix described in the
+[managed reconciler guide](managed-reconciler.md) before treating
+`make reviewable` as meaningful behavior coverage.
+
+# Installation boundary
+
+Official v2.4 documentation installs the resulting package through a
+`pkg.crossplane.io/v1` `Provider` object whose `spec.package` points to a
+registry location.[^provider-package-installation] It also documents digest
+references for deterministic and repeatable installation.[^digest-installation]
+
+The same page explicitly places Provider build instructions outside its scope.
+Use the pinned template and build sources for authoring behavior, and use the
+v2.4 page for the operator-side package installation contract.
+
+[^build-submodule-gitlink]: [Immutable provider-template tree containing the build gitlink](https://api.github.com/repos/crossplane/provider-template/git/trees/a74b386da0ec848036e16ff0a207c5a16bc9827f?recursive=1)
+[^template-makefile]: [Template Go, image, xpkg, and integration targets](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/Makefile#L1-L67)
+[^generation-directives]: [Provider API generation directives](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/generate.go#L20-L27)
+[^reviewable-target]: [Pinned build reviewable target](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/common.mk#L427-L446)
+[^go-targets]: [Pinned Go generation, test, and build targets](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/golang.mk#L101-L169)
+[^xpkg-build]: [Pinned xpkg output and runtime image embedding](https://github.com/crossplane/build/blob/b964dbe0ff0856a762f1a06fe554c647d22af7f0/makelib/xpkg.mk#L67-L89)
+[^provider-package-metadata]: [Template Provider package metadata](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/package/crossplane.yaml#L1-L13)
+[^integration-install]: [Template integration package installation and health wait](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/cluster/local/integration_tests.sh#L139-L174)
+[^provider-package-installation]: [Crossplane v2.4 Provider package installation](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L33-L75)
+[^digest-installation]: [Crossplane v2.4 registry and digest guidance](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L110-L136)

--- a/catalog/sdk/provider-development/index.md
+++ b/catalog/sdk/provider-development/index.md
@@ -1,0 +1,7 @@
+# Provider development SDK
+
+* [Start with provider-template](start-here.md) - Choose the hand-written provider route, pin the template snapshot, and replace its sample surfaces deliberately.
+* [Managed-resource API contracts](managed-resource-apis.md) - Define a modern managed resource and keep authored API inputs separate from generated code and CRDs.
+* [Provider configuration and credentials](provider-configuration.md) - Wire namespaced and cluster-scoped configuration, typed usage tracking, and provider-specific credential handling.
+* [Managed reconciler and external client](managed-reconciler.md) - Implement the typed connector and idempotent Observe, Create, Update, Delete, and Disconnect lifecycle.
+* [Generate, test, build, and package](generate-test-package.md) - Run the template's pinned generation and review gates, build the runtime image, and produce an xpkg.

--- a/catalog/sdk/provider-development/managed-reconciler.md
+++ b/catalog/sdk/provider-development/managed-reconciler.md
@@ -1,0 +1,141 @@
+---
+type: Crossplane Development Guide
+title: Managed reconciler and typed external-client lifecycle
+description: Implement a hand-written provider controller with crossplane-runtime's managed reconciler and typed external connector contract.
+resource: https://github.com/crossplane/crossplane-runtime/tree/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed
+tags: [crossplane, provider-development, sdk, reconciler, controller]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:09:30Z" }
+sources:
+  - id: connector-contract
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L274-L371'
+    title: Typed connector and function adapter contracts
+  - id: external-client-contract
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L374-L539'
+    title: External-client lifecycle and result contracts
+  - id: reconciler-options
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L663-L915'
+    title: Managed reconciler options and construction
+  - id: reconciliation-order
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L1083-L1196'
+    title: Initialization, reference, connection, observation, event, and condition order
+  - id: connection-publication-routing
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L620-L650'
+    title: Modern and legacy connection-detail routing
+  - id: template-controller-setup
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L51-L109'
+    title: Template managed controller setup
+  - id: template-simulated-client
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L172-L254'
+    title: Simulated external-client implementation
+  - id: runtime-resource-fakes
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/fake/mocks.go#L343-L425'
+    title: Runtime managed-resource test fakes
+  - id: runtime-mock-client
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/test/fake.go#L270-L318'
+    title: Configurable controller-runtime mock client
+  - id: template-empty-observe-tests
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype_test.go#L39-L75'
+    title: Template Observe test scaffold
+source_repository: crossplane/crossplane-runtime
+source_tag: v2.3.3
+source_commit: fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827
+supporting_source_repository: crossplane/provider-template
+supporting_source_commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+source_paths: [pkg/reconciler/managed/reconciler.go, pkg/resource/fake/mocks.go, pkg/test/fake.go]
+feature_state: Not stated by selected sources
+feature_state_basis: Unlabelled exported Go SDK contracts and implementation behavior; the stable source tag establishes availability, not maturity.
+---
+
+# Controller construction
+
+`managed.NewReconciler` requires a scheme-registered managed kind. Its defaults
+do not connect to a real external system, so a Provider must install an
+external connector.[^reconciler-options] Prefer the typed connector option for
+the Provider's concrete managed-resource type; the runtime adapts it to the
+managed reconciler.[^connector-contract]
+
+The template composes this with a typed connector, ProviderConfig usage
+tracker, poll interval, safe-start gate, desired-state filtering, rate
+limiting, optional management-policy and change-log features, and optional
+metrics.[^template-controller-setup] Keep only the options the finished
+Provider actually supports and tests.
+
+# Reconciliation sequence
+
+For a non-deleting resource, the selected runtime follows this high-level
+order:[^reconciliation-order]
+
+```text
+Initialize -> Resolve references -> Connect -> Observe
+                                      |
+                                      +-> Create, late-initialize, update, or poll
+                                      +-> Publish connection details and status
+```
+
+Reference resolution is skipped during deletion. After connection, the
+reconciler defers disconnect and uses the observation result to choose the
+next lifecycle action. Connection and observation failures produce warning
+events, mark reconcile-error conditions, and trigger a status-update attempt.[^reconciliation-order]
+
+# External-client contract
+
+The typed client methods are designed to be non-blocking and idempotent:[^external-client-contract]
+
+| Method | Contract boundary |
+|---|---|
+| `Observe` | Read the external resource; do not modify it. Report existence, up-to-date state, and late initialization, and update the managed resource with observed state. |
+| `Create` | Create after observation reports absence; return creation details and any connection details. |
+| `Update` | Reconcile an existing, outdated external resource and return update connection details when applicable. |
+| `Delete` | Request deletion while the Kubernetes managed resource is deleting; repeated calls must be safe. |
+| `Disconnect` | Release per-reconcile external client resources when the loop ends. |
+
+Observation, create, and update results can return connection details. For a
+modern managed resource, the default reconciler routes them through the local
+connection-secret owner contract; the arbitrary-namespace path belongs to the
+deprecated legacy resource shape.[^external-client-contract][^connection-publication-routing]
+
+# Replace the simulated service
+
+The template's client deliberately prints configuration, uses a no-op service,
+assigns a fixed external name, and copies one sample field between desired and
+observed state.[^template-simulated-client] Replace all of that behavior with:
+
+- a provider-specific API client and authentication path;
+- deterministic observation and comparison logic;
+- create/update/delete calls that satisfy the idempotency contract;
+- external-name handling appropriate to the external API; and
+- explicit connection details and error handling where the Provider supports them.
+
+Do not generalize the `MyType` simulation into a Provider behavior claim. Its
+own Alpha API is only a runnable skeleton.
+
+# Tests
+
+crossplane-runtime supplies fake modern and legacy managed resources,
+ProviderConfig-related fakes, and a configurable mock of controller-runtime's
+client.[^runtime-resource-fakes][^runtime-mock-client] The template's
+table-driven `TestObserve` structure contains no test cases in the selected
+snapshot.[^template-empty-observe-tests]
+
+Add cases for at least absence, up-to-date observation, drift, late
+initialization, each external error, and every credential/configuration path
+the Provider exposes. Test repeated lifecycle calls because the SDK contract
+requires idempotency.
+
+# Relationships
+
+The connector obtains its client through
+[ProviderConfig and credential wiring](provider-configuration.md). The managed
+type that enters this reconciler must satisfy the
+[modern managed-resource API contract](managed-resource-apis.md).
+
+[^connector-contract]: [Typed connector and function adapter contracts](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L274-L371)
+[^external-client-contract]: [External-client lifecycle and result contracts](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L374-L539)
+[^reconciler-options]: [Managed reconciler options and construction](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L663-L915)
+[^reconciliation-order]: [Initialization, reference, connection, observation, event, and condition order](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L1083-L1196)
+[^connection-publication-routing]: [Modern and legacy connection-detail routing](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/reconciler/managed/reconciler.go#L620-L650)
+[^template-controller-setup]: [Template managed controller setup](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L51-L109)
+[^template-simulated-client]: [Simulated external-client implementation](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L172-L254)
+[^runtime-resource-fakes]: [Runtime managed-resource test fakes](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/fake/mocks.go#L343-L425)
+[^runtime-mock-client]: [Configurable controller-runtime mock client](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/test/fake.go#L270-L318)
+[^template-empty-observe-tests]: [Template Observe test scaffold](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype_test.go#L39-L75)

--- a/catalog/sdk/provider-development/managed-resource-apis.md
+++ b/catalog/sdk/provider-development/managed-resource-apis.md
@@ -1,0 +1,92 @@
+---
+type: Crossplane Development Guide
+title: Managed-resource API contracts for a hand-written provider
+description: Define a modern managed-resource API from authored Go types and generate its runtime method sets and CRD artifacts.
+resource: https://github.com/crossplane/provider-template/tree/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample
+tags: [crossplane, provider-development, sdk, managed-resource, api, code-generation]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:09:30Z" }
+sources:
+  - id: sample-managed-resource-type
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/mytype_types.go#L29-L73'
+    title: Sample modern managed-resource type
+  - id: sample-api-version
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/groupversion_info.go#L17-L32'
+    title: Sample managed-resource group and version
+  - id: managed-resource-interfaces
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/interfaces.go#L192-L225'
+    title: Managed, ModernManaged, and deprecated LegacyManaged interfaces
+  - id: generation-directives
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/generate.go#L20-L27'
+    title: Provider API generation directives
+  - id: angryjet-methodsets
+    resource: 'https://github.com/crossplane/crossplane-tools/blob/60e57f817ad1f80dcf052a940cf923fde56fab1f/cmd/angryjet/main.go#L66-L118'
+    title: angryjet generated method-set command
+source_repository: crossplane/provider-template
+source_commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+supporting_source_repositories:
+  - repository: crossplane/crossplane-runtime
+    tag: v2.3.3
+    commit: fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827
+  - repository: crossplane/crossplane-tools
+    commit: 60e57f817ad1f80dcf052a940cf923fde56fab1f
+source_paths: [apis/sample/v1alpha1/mytype_types.go, apis/sample/v1alpha1/groupversion_info.go, apis/generate.go]
+feature_state: Alpha
+feature_state_basis: The owning sample managed-resource API is served as sample.template.crossplane.io/v1alpha1; this state does not transfer to crossplane-runtime.
+---
+
+# Authored API shape
+
+The template's `MyType` demonstrates a namespaced modern managed resource:
+
+| Area | Template shape | Provider responsibility |
+|---|---|---|
+| `spec` | Embeds `ManagedResourceSpec` | Define provider-specific desired parameters under `forProvider` |
+| `status` | Embeds `ManagedResourceStatus` | Define provider-observed fields under `atProvider` |
+| Kubernetes scope | Namespaced | Choose and generate the intended scope deliberately |
+| API version | `sample.template.crossplane.io/v1alpha1` | Select and maintain the provider's own API lifecycle |
+
+The sample types establish the scaffold shape, not a schema for any real
+external service.[^sample-managed-resource-type][^sample-api-version] Replace
+`MyTypeParameters` and `MyTypeObservation` with fields derived from the external
+API and Kubernetes API conventions.
+
+# Runtime interface contract
+
+In crossplane-runtime v2.3.3, `resource.Managed` combines Kubernetes object,
+management-policy, and condition behavior. `resource.ModernManaged` adds a
+local connection-secret target and a typed ProviderConfig reference.[^managed-resource-interfaces]
+
+Use the modern contract for new namespace-scoped managed resources. The SDK's
+`LegacyManaged` shape carries an arbitrary-namespace connection Secret,
+untyped ProviderConfig reference, and deletion policy; it is explicitly
+deprecated for new namespace-scoped managed resources.[^managed-resource-interfaces]
+
+The Go interface maturity is **Not stated by selected sources**. The **Alpha**
+state on this page belongs to the template's sample `v1alpha1` API, not to the
+runtime package.
+
+# Authored versus generated files
+
+Edit the API type and registration files. The template's generation directive
+then:
+
+1. removes the existing packaged CRDs;
+2. runs `controller-gen` for deepcopy methods and v1 CRDs; and
+3. runs `angryjet generate-methodsets` for Crossplane interface methods.[^generation-directives][^angryjet-methodsets]
+
+Treat `zz_generated*.go` and `package/crds/**` as generated outputs. Review
+their diff after changing API types, but make the corresponding authored Go
+types or generator configuration the source change.
+
+# Relationships
+
+The API's typed `providerConfigRef` connects it to
+[provider configuration and credential wiring](provider-configuration.md).
+The generated managed-resource methods allow the
+[managed reconciler](managed-reconciler.md) to operate on the resource.
+
+[^sample-managed-resource-type]: [Sample modern managed-resource type](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/mytype_types.go#L29-L73)
+[^sample-api-version]: [Sample managed-resource group and version](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/sample/v1alpha1/groupversion_info.go#L17-L32)
+[^managed-resource-interfaces]: [Managed, ModernManaged, and deprecated LegacyManaged interfaces](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/interfaces.go#L192-L225)
+[^generation-directives]: [Provider API generation directives](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/generate.go#L20-L27)
+[^angryjet-methodsets]: [angryjet generated method-set command](https://github.com/crossplane/crossplane-tools/blob/60e57f817ad1f80dcf052a940cf923fde56fab1f/cmd/angryjet/main.go#L66-L118)

--- a/catalog/sdk/provider-development/provider-configuration.md
+++ b/catalog/sdk/provider-development/provider-configuration.md
@@ -1,0 +1,110 @@
+---
+type: Crossplane Development Guide
+title: Provider configuration, credential extraction, and usage tracking
+description: Implement namespaced and cluster-scoped provider configuration with typed usage records and provider-specific credential handling.
+resource: https://github.com/crossplane/provider-template/tree/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/v1alpha1
+tags: [crossplane, provider-development, sdk, providerconfig, credentials]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:09:30Z" }
+sources:
+  - id: provider-config-types
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/v1alpha1/types.go#L22-L110'
+    title: Template ProviderConfig, credentials, and usage types
+  - id: provider-config-schema
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/package/crds/template.crossplane.io_providerconfigs.yaml#L52-L112'
+    title: Generated ProviderConfig credential schema
+  - id: provider-config-controllers
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/config/config.go#L30-L82'
+    title: ProviderConfig controller wiring
+  - id: template-connector
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L120-L161'
+    title: Template config lookup and credential extraction
+  - id: common-credential-extractor
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L60-L113'
+    title: crossplane-runtime common credential extractor
+  - id: typed-usage-tracker
+    resource: 'https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L157-L207'
+    title: Typed ProviderConfig usage tracker
+  - id: provider-config-examples
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/examples/provider/config.yaml#L15-L38'
+    title: Template Secret credential examples
+  - id: readme-secret-only-description
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L3-L10'
+    title: README ProviderConfig summary
+source_repository: crossplane/provider-template
+source_commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+supporting_source_repository: crossplane/crossplane-runtime
+supporting_source_tag: v2.3.3
+supporting_source_commit: fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827
+source_paths: [apis/v1alpha1/types.go, internal/controller/config/config.go, internal/controller/mytype/mytype.go, examples/provider/config.yaml]
+feature_state: Alpha
+feature_state_basis: The owning template ProviderConfig and ProviderConfigUsage APIs are served as template.crossplane.io/v1alpha1.
+---
+
+# Configuration API
+
+The template supplies one shared configuration spec across two scopes and one
+typed usage kind:[^provider-config-types]
+
+| Kind | Scope | Purpose |
+|---|---|---|
+| `ProviderConfig` | Namespaced | Configuration selected by a namespaced managed resource |
+| `ClusterProviderConfig` | Cluster | Shared cluster-scoped configuration |
+| `ProviderConfigUsage` | Namespaced | Typed record linking a managed resource to either configuration kind |
+
+Both configuration controllers use crossplane-runtime's ProviderConfig
+reconciler and watch usage records to enqueue the referenced configuration.[^provider-config-controllers]
+The whole template API is `template.crossplane.io/v1alpha1`, so these concrete
+sample APIs are **Alpha**.
+
+# Credential sources
+
+The authored type and generated schema admit `None`, `Secret`,
+`InjectedIdentity`, `Environment`, and `Filesystem` credential sources.[^provider-config-types][^provider-config-schema]
+The template connector passes that selection to
+`CommonCredentialExtractor`.[^template-connector]
+
+The runtime helper handles `None`, Secret, environment, and filesystem
+selectors. It deliberately does not provide a generic InjectedIdentity
+implementation because identity injection is provider-specific.[^common-credential-extractor]
+If the new provider exposes `InjectedIdentity`, add and test its provider-specific
+handling rather than assuming the common extractor implements it.
+
+The README calls the sample ProviderConfig Secret-only, but the selected types
+and generated schema expose all five sources.[^readme-secret-only-description][^provider-config-types][^provider-config-schema]
+This is a source disagreement: use the types and schema for API shape, while
+treating the README sentence as incomplete.
+
+# Usage-before-configuration order
+
+The runtime usage tracker derives a typed usage name from the managed-resource
+UID and requires the ProviderConfig reference to include its kind. Its contract
+specifically calls for tracking usage before trying to use the configuration,
+so a misconfigured ProviderConfig is still represented by a usage record.[^typed-usage-tracker]
+
+The template connector follows that order:
+
+1. track the selected config usage;
+2. fetch either `ProviderConfig` or `ClusterProviderConfig` by the typed kind;
+3. extract credentials; and
+4. construct the provider-specific external service client.[^template-connector]
+
+The checked-in examples demonstrate Secret selectors for both configuration
+scopes.[^provider-config-examples] They do not demonstrate the other admitted
+credential sources; add provider-specific tests and examples for every source
+the finished API retains.
+
+# Relationships
+
+Managed resources carry the typed reference described in
+[managed-resource API contracts](managed-resource-apis.md). The connector uses
+the resolved configuration to create the client used by the
+[managed reconciler lifecycle](managed-reconciler.md).
+
+[^provider-config-types]: [Template ProviderConfig, credentials, and usage types](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/apis/v1alpha1/types.go#L22-L110)
+[^provider-config-schema]: [Generated ProviderConfig credential schema](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/package/crds/template.crossplane.io_providerconfigs.yaml#L52-L112)
+[^provider-config-controllers]: [ProviderConfig controller wiring](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/config/config.go#L30-L82)
+[^template-connector]: [Template config lookup and credential extraction](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/internal/controller/mytype/mytype.go#L120-L161)
+[^common-credential-extractor]: [crossplane-runtime common credential extractor](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L60-L113)
+[^typed-usage-tracker]: [Typed ProviderConfig usage tracker](https://github.com/crossplane/crossplane-runtime/blob/fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827/pkg/resource/providerconfig.go#L157-L207)
+[^provider-config-examples]: [Template Secret credential examples](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/examples/provider/config.yaml#L15-L38)
+[^readme-secret-only-description]: [README ProviderConfig summary](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L3-L10)

--- a/catalog/sdk/provider-development/start-here.md
+++ b/catalog/sdk/provider-development/start-here.md
@@ -1,0 +1,94 @@
+---
+type: Crossplane Development Guide
+title: Start a provider project with provider-template
+description: Use the pinned provider-template snapshot as the entry point for a hand-written Crossplane provider while preserving its version and example boundaries.
+resource: https://github.com/crossplane/provider-template
+tags: [crossplane, provider-development, sdk, go, provider-template]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:09:30Z" }
+sources:
+  - id: provider-responsibilities
+    resource: 'https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L7-L29'
+    title: Crossplane v2.4 provider responsibilities
+  - id: template-purpose
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L1-L10'
+    title: provider-template purpose and included sample surfaces
+  - id: template-workflow
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L12-L32'
+    title: provider-template development workflow
+  - id: selected-dependencies
+    resource: 'https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/go.mod#L1-L19'
+    title: provider-template Go and Crossplane dependencies
+  - id: older-provider-guide-version-boundary
+    resource: 'https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/contributing/guide-provider-development.md#L60-L74'
+    title: Older provider guide runtime target and provider-template recommendation
+source_repository: crossplane/provider-template
+source_commit: a74b386da0ec848036e16ff0a207c5a16bc9827f
+source_revision: immutable main snapshot
+source_paths: [README.md, go.mod]
+crossplane_documentation_series: v2.4
+feature_state: Not stated by selected sources
+feature_state_basis: Unlabelled provider-development workflow and template snapshot; source stability does not establish product maturity.
+---
+
+# Overview
+
+A Provider defines Kubernetes managed-resource APIs and implements the
+authentication, external API calls, and controller logic that reconcile those
+resources.[^provider-responsibilities] For a hand-written Go Provider,
+`crossplane/provider-template` supplies a minimal project containing provider
+configuration APIs, a sample managed resource, and a controller skeleton.[^template-purpose]
+
+First decide whether a hand-written Provider is the right implementation
+family. If a suitable Terraform provider exists, compare this route with the
+[Upjet-generated and other provider families](/providers/provider-landscape.md)
+before committing to custom controllers.
+
+# Selected source boundary
+
+This guide uses provider-template commit
+`a74b386da0ec848036e16ff0a207c5a16bc9827f`. This workflow pins that exact
+`main` snapshot instead of assigning it a semantic-version release identity.
+
+The snapshot declares Go 1.25.11 and selects Crossplane APIs and
+`crossplane-runtime/v2` v2.3.3.[^selected-dependencies] Current provider
+orientation is taken from the Crossplane v2.4 documentation, but SDK behavior
+in this section stays version-matched to the template's v2.3.3 dependency.
+
+# Bootstrap sequence
+
+After creating a repository from the template, its documented sequence is:
+
+```shell
+make submodules
+make provider.prepare provider=<CamelCaseName>
+make provider.addtype provider=<CamelCaseName> group=<lowercase-group> kind=<Kind>
+```
+
+Then replace the sample API group, managed-resource controller, and
+ProviderConfig implementation; register the new API and controller; run
+`make reviewable`; and run `make build`.[^template-workflow]
+
+Treat every generated sample as a replacement checklist, not production
+behavior. Continue with the [managed-resource API contract](managed-resource-apis.md),
+[provider configuration](provider-configuration.md), and
+[managed reconciler](managed-reconciler.md) before relying on the build and
+package outputs.
+
+# Documentation boundary
+
+The older contributing provider-development guide still recommends
+provider-template, but the same section says it targets crossplane-runtime
+v0.9.0.[^older-provider-guide-version-boundary] It also contains older
+cluster-scoped assumptions. This knowledge therefore uses the current pinned
+template and its exact runtime dependency for API and behavior claims; the
+older guide is not treated as the current SDK specification.
+
+Neither the template snapshot nor the selected documentation assigns a
+lifecycle state to the provider-development workflow. Its feature state is
+**Not stated by selected sources**.
+
+[^provider-responsibilities]: [Crossplane v2.4 provider responsibilities](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/v2.4/packages/providers.md#L7-L29)
+[^template-purpose]: [provider-template purpose and included sample surfaces](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L1-L10)
+[^template-workflow]: [provider-template development workflow](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/README.md#L12-L32)
+[^selected-dependencies]: [provider-template Go and Crossplane dependencies](https://github.com/crossplane/provider-template/blob/a74b386da0ec848036e16ff0a207c5a16bc9827f/go.mod#L1-L19)
+[^older-provider-guide-version-boundary]: [Older provider guide runtime target and provider-template recommendation](https://github.com/crossplane/crossplane/blob/09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d/contributing/guide-provider-development.md#L60-L74)


### PR DESCRIPTION
## Summary

- add a provider-development SDK route grounded in the official `crossplane/provider-template`
- document managed-resource APIs, provider configuration, reconciler contracts, and the generate/test/package workflow
- record immutable source identities, provenance, lifecycle boundaries, and claim-level evidence

## Selected sources

- `crossplane/provider-template` at `a74b386da0ec848036e16ff0a207c5a16bc9827f`
- `crossplane-runtime/v2` v2.3.3 at `fcf6aaa11ef4b56b9a8b1b91a446e0f6b8fc2827`
- `crossplane/build` at `b964dbe0ff0856a762f1a06fe554c647d22af7f0`
- `crossplane-tools` at `60e57f817ad1f80dcf052a940cf923fde56fab1f`
- Crossplane v2.4.0 and matching v2.4 documentation for current orientation

## Validation

- `mise run lint`
- OKF validation: 0 errors, 0 warnings
- MCP test suite: 31 passed
- `okf-reviewer`: APPROVED
- legacy Claims, v1 XR semantics, and deprecated XRD v1 material excluded
