### PR TITLE
Add optional control plane project workflow

### DIFF
--- a/.agents/skills/okf/references/sources.yaml
+++ b/.agents/skills/okf/references/sources.yaml
@@ -256,6 +256,27 @@ primary_sources:
       - examples requiring deprecated v1 XRD or legacy v1 XR semantics
 
 documentation_sources:
+  - id: crossplane-cli-docs
+    repository: crossplane/docs
+    kind: official-documentation
+    domain: crossplane-cli
+    core_scope: false
+    agent: okf-crossplane-researcher
+    revision_policy: reuse-existing-lock
+    lock_id: crossplane-docs-v2.4
+    paths:
+      - content/cli/v2.4/get-started/get-started-with-control-plane-projects.md
+      - content/cli/v2.4/command-reference.md
+    focus:
+      - control-plane-projects
+      - composition-authoring
+      - local-development
+      - package-build-and-push
+    legacy_exclusions:
+      - Claims and claim workflows
+      - deprecated CompositeResourceDefinition v1 schema
+      - legacy v1 composite-resource semantics
+    version_scope: cli-v2.4
   - id: crossplane-docs
     repository: crossplane/docs
     kind: official-documentation

--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -5,6 +5,33 @@ title: Crossplane catalog claim ledger
 
 # Scope
 
+## Optional Crossplane control plane projects for new Compositions
+
+Reused the existing `crossplane-docs-v2.4` lock at
+`f51137d2f8e92a167bb580be528c78b879ed406d` and the existing
+`crossplane-cli` v2.4.0 lock at
+`ef9b974770a45e085aacee3b2cdda6284ab6cf51`; neither source identity was
+advanced. The official CLI documentation is the authority for the documented
+workflow and explicit Beta state. CLI source is used only to establish the
+project metadata boundary. Claims, deprecated XRD v1, legacy v1 XR semantics,
+historical design, and project history were excluded. No source text or
+examples were copied or adapted.
+
+| Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
+|---|---|---|---|---|---|
+| cli/control-plane-projects | The `crossplane project` command group is explicitly Beta and may change in a future release. | documented-guidance | official-documentation | direct | Beta; [project command lifecycle](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1095-L1103) |
+| cli/control-plane-projects | A control plane project groups API definitions, Compositions, embedded Functions, examples, and `crossplane-project.yaml`; `project init` creates the standard directories. | documented-guidance | official-documentation | direct | Beta project workflow; [project contents](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L91-L145), [initialization](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1184-L1238) |
+| cli/control-plane-projects | The documented route can generate an XRD from an example XR or SimpleSchema, generate a Composition, add dependencies, and scaffold an embedded Function. | documented-guidance | official-documentation | direct | Beta because the route uses the Beta project capability; [XRD generation](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L162-L317), [Composition and Function workflow](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L323-L424) |
+| cli/control-plane-projects | In a project directory, local Composition rendering discovers and builds embedded Functions without the standalone Functions manifest argument. | documented-guidance | official-documentation | direct | Beta project workflow; [project-mode rendering](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L1032) |
+| cli/control-plane-projects | `crossplane project run` creates a KIND development control plane and local registry, builds and pushes embedded Function and Configuration packages, installs the Configuration, and selects that cluster in kubectl. | documented-guidance | official-documentation | direct | Beta project workflow; [local project run](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1034-L1058) |
+| cli/control-plane-projects | Project build and push provide the documented route to package a project for an existing Crossplane cluster. | documented-guidance | official-documentation | direct | Beta project workflow; [build and push](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1105-L1128) |
+| cli/control-plane-projects | The Project metadata type is not a Kubernetes resource; it describes a buildable Configuration and its repository, dependencies, Functions, paths, architectures, and schema generation. | API | primary | direct | The containing project command workflow is explicitly Beta; [Project API](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120), [project paths](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L150-L171) |
+
+The instruction to ask before wrapping a new Composition is a user-requested
+catalog authoring policy. It is intentionally labelled as such and is not
+attributed to Crossplane documentation. Project mode remains opt-in; the
+standalone manifest route remains available.
+
 ## Provider development SDK from provider-template
 
 Selected the user-requested `crossplane/provider-template` `main` snapshot at

--- a/catalog/cli/control-plane-projects.md
+++ b/catalog/cli/control-plane-projects.md
@@ -1,0 +1,138 @@
+---
+type: Crossplane Development Guide
+title: Opt in to a Crossplane control plane project
+description: Choose the Beta CLI project wrapper explicitly before scaffolding, locally running, and packaging a new Composition-backed API.
+resource: https://docs.crossplane.io/cli/latest/get-started/get-started-with-control-plane-projects/
+tags: [crossplane, cli, composition, project, authoring, packaging]
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:35:21Z" }
+sources:
+  - id: project-command-beta-state
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1095-L1103
+    title: Crossplane project command Beta state
+  - id: project-definition-and-layout
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L91-L145
+    title: Control plane project definition and layout
+  - id: project-init-contract
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1184-L1238
+    title: Project initialization contract
+  - id: project-generation-workflow
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L162-L424
+    title: API, Composition, dependency, and Function generation workflow
+  - id: project-render-workflow
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L1032
+    title: Project-mode Composition rendering
+  - id: project-run-workflow
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1034-L1058
+    title: Local project development control plane
+  - id: project-runtime-prerequisites
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L80-L89
+    title: Local project runtime prerequisites
+  - id: project-build-and-push-workflow
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1105-L1128
+    title: Project build and push workflow
+  - id: xrd-generation-boundary
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L235-L238
+    title: Example-XR XRD generation boundary
+  - id: project-api-boundary
+    resource: https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120
+    title: Project metadata API boundary
+documentation_series: cli-v2.4
+source_repository: crossplane/docs
+source_commit: f51137d2f8e92a167bb580be528c78b879ed406d
+source_paths:
+  - content/cli/v2.4/get-started/get-started-with-control-plane-projects.md
+  - content/cli/v2.4/command-reference.md
+supporting_sources:
+  - repository: crossplane/cli
+    commit: ef9b974770a45e085aacee3b2cdda6284ab6cf51
+    paths:
+      - apis/dev/v1alpha1/project_types.go
+feature_state: Beta
+feature_state_basis: The locked CLI v2.4 command reference explicitly labels the crossplane project command group Beta and warns that Beta features may change.
+---
+
+# Agent opt-in gate
+
+Before creating files for a new Composition or Composition-backed API, ask the
+requester one question unless they already selected a structure:
+
+> Would you like this wrapped as a Crossplane control plane project (CLI Beta),
+> or should I create standalone Composition manifests?
+
+Project mode is opt-in. Do not initialize a project, add
+`crossplane-project.yaml`, or reorganize existing manifests unless the
+requester chooses the project route. This decision rule is a catalog authoring
+policy, not a Crossplane requirement.
+
+When the requester chooses standalone authoring, follow the
+[standalone Composition manifest layout](/core/composition-project-layout.md)
+and [standalone local rendering](/cli/local-composition-rendering.md).
+
+# What the wrapper provides
+
+The Crossplane CLI defines a project as a directory containing API definitions,
+Compositions, embedded Functions, examples, tests, operations, and a
+`crossplane-project.yaml` metadata file.[^project-definition-and-layout] The
+`crossplane project` command group is explicitly **Beta**; the locked v2.4
+documentation warns that Beta features may change.[^project-command-beta-state]
+
+Choose this route when the requester wants the CLI to manage an end-to-end
+authoring lifecycle:
+
+- scaffold the standard project directories and metadata;
+- generate an XRD and Composition;
+- record dependencies and generate an embedded Function;
+- discover and build embedded Functions during local rendering;
+- run the packages on a local KIND development control plane; and
+- build and push the resulting Configuration and embedded Function packages.
+
+# Documented route
+
+1. Initialize the selected directory with `crossplane project init <name>`.
+   The name must be a DNS-1035 label; the command creates the project metadata
+   and standard directories.[^project-init-contract]
+2. Define the XR API, then use the CLI generation commands where they fit the
+   requested authoring approach. The guide covers XRD generation from an
+   example XR or SimpleSchema, Composition generation, dependency addition,
+   and embedded Function generation.[^project-generation-workflow]
+3. From the project directory, render the example XR and Composition. Project
+   mode discovers and builds the embedded Functions, so this invocation does
+   not take the standalone Functions manifest argument.[^project-render-workflow]
+4. With a Docker-compatible runtime available, use `crossplane project run`
+   for the local KIND control plane and registry. The command builds and pushes
+   the embedded Function and Configuration packages, installs the
+   Configuration, and selects the development cluster in the current kubectl
+   context.[^project-run-workflow]
+5. Use `crossplane project build` and `crossplane project push` when the
+   requester wants to publish the packages for installation on an existing
+   Crossplane cluster.[^project-build-and-push-workflow]
+
+# Boundaries
+
+- Project commands are Beta; do not hide that lifecycle state when offering
+  the option.[^project-command-beta-state]
+- `crossplane-project.yaml` uses the CLI's Project metadata type. It describes
+  a buildable Configuration and its dependencies, Functions, paths,
+  architectures, and schema generation; it is not a Kubernetes resource and
+  has no status.[^project-api-boundary]
+- Local project execution requires a Docker-compatible runtime because the
+  guide builds Functions and creates a KIND cluster.[^project-runtime-prerequisites]
+- Generating an XRD from an example XR cannot express field types, defaults,
+  validation rules, or descriptions. Use the guide's SimpleSchema route or
+  author the XRD schema directly when those controls are required.[^xrd-generation-boundary]
+- Project wrapping does not replace the Composition design and verification
+  gates. Continue through the
+  [Composition developer route](/composition-developer-starter.md), including
+  provider schema selection, security review, render assertions, live smoke
+  tests, and package validation.
+
+[^project-command-beta-state]: [Crossplane project command Beta state](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1095-L1103)
+[^project-definition-and-layout]: [Control plane project definition and layout](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L91-L145)
+[^project-init-contract]: [Project initialization contract](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1184-L1238)
+[^project-generation-workflow]: [API, Composition, dependency, and Function generation workflow](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L162-L424)
+[^project-render-workflow]: [Project-mode Composition rendering](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L1032)
+[^project-run-workflow]: [Local project development control plane](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1034-L1058)
+[^project-runtime-prerequisites]: [Local project runtime prerequisites](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L80-L89)
+[^project-build-and-push-workflow]: [Project build and push workflow](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1105-L1128)
+[^xrd-generation-boundary]: [Example-XR XRD generation boundary](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L235-L238)
+[^project-api-boundary]: [Project metadata API boundary](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120)

--- a/catalog/cli/index.md
+++ b/catalog/cli/index.md
@@ -1,3 +1,4 @@
 # Crossplane CLI
 
+* [Opt in to a control plane project](control-plane-projects.md) - Use the Beta project workflow only after the requester chooses it for a new Composition.
 * [Render a Composition locally](local-composition-rendering.md) - Render a Pipeline Composition and its Functions locally from YAML inputs.

--- a/catalog/cli/local-composition-rendering.md
+++ b/catalog/cli/local-composition-rendering.md
@@ -4,7 +4,7 @@ title: Render a Composition locally
 description: Use the Crossplane CLI to execute a Pipeline Composition and its Functions locally against an example XR.
 resource: https://github.com/crossplane/cli
 tags: [crossplane, cli, composition, rendering, testing]
-generated: { by: "process:okf-v0.2-migration", at: "2026-08-20T06:45:13Z" }
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:35:21Z" }
 sources:
   - id: cli-render-behavior-output-and-docker-guidance
     resource: 'https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/cmd/crossplane/render/xr/help/render.md#L1-L35'
@@ -51,6 +51,9 @@ sources:
   - id: standalone-file-based-render-requires-the-functions-argument
     resource: 'https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/cmd/crossplane/render/xr/cmd.go#L396-L413'
     title: 'Standalone file-based render requires the Functions argument'
+  - id: project-mode-render-discovers-functions
+    resource: 'https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L936'
+    title: 'Project-mode render discovers and builds Functions'
 source_repository: crossplane/cli
 source_commit: ef9b974770a45e085aacee3b2cdda6284ab6cf51
 source_paths:
@@ -61,6 +64,10 @@ source_paths:
   - cmd/crossplane/validate/help/validate.md
   - pkg/validate/validate.go
 supporting_sources:
+  - repository: crossplane/docs
+    commit: f51137d2f8e92a167bb580be528c78b879ed406d
+    paths:
+      - content/cli/v2.4/get-started/get-started-with-control-plane-projects.md
   - repository: CustomResourceDefinition/catalog
     commit: 0584c9f7e6eaef8367cd65e59266d8ad49764f0c
     paths:
@@ -106,6 +113,11 @@ Outside a Crossplane Project, the Functions input is required. It may be a
 multi-document YAML file or a directory of YAML files. A Functions file is a
 CLI input boundary: do not put a Provider, ProviderConfig,
 ManagedResourceActivationPolicy, Composition, or XR in it.[^functions-only-loader-validation][^standalone-file-based-render-requires-the-functions-argument]
+
+For project-managed rendering, first follow the catalog's
+[control plane project opt-in](/cli/control-plane-projects.md). In a project
+directory, the CLI can discover and build embedded Functions instead of taking
+the standalone Functions manifest described here.[^project-mode-render-discovers-functions]
 
 ## Strict Functions-only rule
 
@@ -236,3 +248,4 @@ not change the documented v2.4.0 behavior.[^pr-148-change-validation-image-defau
 [^crd-catalog-definition-files-and-definition-examples]: [CRD Catalog definition files and definition examples](https://github.com/CustomResourceDefinition/catalog/blob/0584c9f7e6eaef8367cd65e59266d8ad49764f0c/README.md#L20-L38)
 [^cli-issue-195-built-in-secret-missing-definition-report]: [CLI issue #195: built-in Secret missing-definition report](https://github.com/crossplane/cli/issues/195), opened by human author `@jkroepke` on 2026-07-16; researched 2026-07-16.
 [^standalone-file-based-render-requires-the-functions-argument]: [Standalone file-based render requires the Functions argument](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/cmd/crossplane/render/xr/cmd.go#L396-L413)
+[^project-mode-render-discovers-functions]: [Project-mode render discovers and builds Functions](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L936)

--- a/catalog/composition-developer-starter.md
+++ b/catalog/composition-developer-starter.md
@@ -4,11 +4,27 @@ title: Crossplane v2 Composition developer route
 description: A routing guide for designing, implementing, testing, and packaging a Crossplane v2 Composition.
 resource: https://docs.crossplane.io/v2.3/composition/compositions/
 tags: [crossplane, composition, composition-authoring, development]
-generated: { by: "process:okf-v0.2-migration", at: "2026-08-20T06:45:13Z" }
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:35:21Z" }
 crossplane_release: v2.3.3
 documentation_series: v2.3
 feature_state: Not stated by selected sources
 ---
+
+# Ask about the project wrapper first
+
+When a user requests a new Composition or a new Composition-backed API and has
+not already chosen a repository structure, ask:
+
+> Would you like this wrapped as a Crossplane control plane project (CLI Beta),
+> or should I create standalone Composition manifests?
+
+Treat the project wrapper as an explicit opt-in. Do not scaffold or migrate to
+project mode unless the user chooses it. When the user opts in, follow the
+[control plane project workflow](cli/control-plane-projects.md). When the user
+chooses standalone manifests, use the
+[standalone manifest layout](core/composition-project-layout.md).
+
+This question is a catalog authoring policy, not a Crossplane requirement.
 
 # Use this as a route, not a checklist to stop reading
 

--- a/catalog/core/composition-project-layout.md
+++ b/catalog/core/composition-project-layout.md
@@ -1,9 +1,9 @@
 ---
 type: Crossplane Development Guide
-title: Reference layout for a Composition project
-description: A small manifest layout that keeps Composition authoring inputs distinct from the CLI Functions-only render input.
+title: Reference layout for standalone Composition manifests
+description: A small standalone manifest layout that keeps Composition authoring inputs distinct from the CLI Functions-only render input.
 tags: [crossplane, composition, authoring, cli, project-layout]
-generated: { by: "process:okf-v0.2-migration", at: "2026-08-20T06:45:13Z" }
+generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:35:21Z" }
 sources:
   - id: pipeline-composition-and-xr-gvk-validation
     resource: 'https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/cmd/crossplane/render/xr/cmd.go#L118-L158'
@@ -51,10 +51,18 @@ supporting_sources:
 feature_state: Not stated by selected sources
 ---
 
+# Scope boundary
+
+This is a catalog convention for standalone manifests, not the Crossplane CLI
+control plane project structure. Use it when the requester chooses standalone
+authoring. If the requester opts in to a project wrapper, use the
+[control plane project workflow](/cli/control-plane-projects.md) instead.
+
 # Reference layout
 
-Use this deliberately small layout only when the Composition project contains
-no files and the user has not provided other layout instructions:
+Use this deliberately small layout only when the standalone Composition
+workspace contains no files and the user has not provided other layout
+instructions:
 
 ```text
 .

--- a/catalog/core/index.md
+++ b/catalog/core/index.md
@@ -13,7 +13,7 @@
 * [Tenant XR API and admission security](tenant-xr-api-security.md) - Organization-specific API-group, RBAC, namespace, and admission-policy hardening guidance.
 * [Composition](composition.md) - The current function-pipeline API for composing resources.
 * [Composed-resource identity and replacement](composed-resource-identity-and-replacement.md) - Why changing metadata.name under an unchanged logical key does not rename or replace an existing object, and how to stage replacement.
-* [Composition project layout](composition-project-layout.md) - A reference manifest layout that keeps render inputs and provider setup distinct.
+* [Standalone Composition manifest layout](composition-project-layout.md) - A reference layout that keeps standalone render inputs and provider setup distinct.
 * [Controlled rollout design for Composition Functions](controlled-rollout-of-composition-functions-design.md) - Historical accepted proposal; selected-release source proof shows its rollout API is not current behavior.
 * [Composed-resource RBAC](composed-resource-rbac.md) - Why Crossplane cannot manage every Kubernetes resource kind by default and how to grant additional access.
 * [Real-time composition reconciliation](realtime-composition-reconciliation.md) - Beta composed-resource watches, TTL requeues, and required-resource refresh boundaries.

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,6 +1,7 @@
 # Catalog Update Log
 
 ## 2026-08-21
+* **Creation**: Added an explicit opt-in decision for wrapping new Compositions as Beta Crossplane control plane projects, while preserving and clarifying the standalone manifest route.
 * **Creation**: Added a provider-development SDK route from an immutable provider-template snapshot through modern managed-resource APIs, ProviderConfig and credentials, typed reconciliation, generation, testing, and xpkg packaging.
 * **Creation**: Added a user-selected function-kro v0.3.0 preview reference for the package, Alpha ResourceGraph input, and graph evaluation behavior, backed by the exact KRO v0.9.2 documentation selected in go.mod.
 


### PR DESCRIPTION
## Summary

- document Crossplane CLI control plane Projects as a Beta, optional wrapper for new Composition-backed APIs
- require the Composition developer route to ask whether the requester wants project mode or standalone manifests
- preserve and clarify the existing standalone layout and rendering route

## Source selection

- reuse the existing `crossplane-docs-v2.4` lock at `f51137d2f8e92a167bb580be528c78b879ed406d`
- reuse the existing `crossplane-cli` v2.4.0 lock at `ef9b974770a45e085aacee3b2cdda6284ab6cf51`
- do not advance `.okf/sources.lock.yaml`

## Evidence boundaries

- the official CLI v2.4 command reference explicitly labels `crossplane project` Beta
- the opt-in question is identified as catalog authoring policy, not a Crossplane requirement
- CLI documentation remains a separate catalog domain from Crossplane Core
- Claims, deprecated XRD v1, and legacy v1 XR semantics are excluded

## Validation

- `mise run lint`
- OKF validation: 0 errors, 0 warnings
- MCP test suite: 31 passed
- `okf-reviewer`: APPROVED
