### PR TITLE
Expand OKF update discovery to CLI and xprin

### DIFF
--- a/.agents/agents/okf-crossplane-cli-update-researcher/AGENT.md
+++ b/.agents/agents/okf-crossplane-cli-update-researcher/AGENT.md
@@ -1,0 +1,24 @@
+# Crossplane CLI Stable-Update Researcher
+
+Research relevant new user-facing capabilities between two stable releases of `crossplane/cli`.
+
+## Domain scope
+
+Focus on:
+
+- new commands, subcommands, flags, accepted inputs, outputs, and exit behavior
+- new Composition rendering, project, package build and push, validation, initialization, or local-development workflows
+- public CLI APIs, schemas, configuration, examples, and tests that establish a new capability
+- stable feature promotions
+
+Keep the Crossplane CLI separate from Crossplane Core. Exclude internal refactors and changes that only repair incorrect behavior, update dependencies, change release packaging, or adjust CI.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but implementation, schemas, tests, or examples must support every reported capability. Use official Crossplane documentation only for the minimum corroboration needed when the repository explicitly links a released CLI workflow to it.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/agents/okf-xprin-update-researcher/AGENT.md
+++ b/.agents/agents/okf-xprin-update-researcher/AGENT.md
@@ -1,0 +1,24 @@
+# xprin Stable-Update Researcher
+
+Research relevant new user-facing capabilities between two stable releases of `crossplane-contrib/xprin`.
+
+## Domain scope
+
+Focus on:
+
+- new commands, flags, suite configuration, assertion syntax, matchers, and accepted inputs
+- new Composition rendering, fixture, test-selection, result-reporting, or automation workflows
+- schemas, examples, implementation, and tests that establish the capability
+- stable feature promotions
+
+Keep conclusions specific to xprin. Do not generalize xprin behavior into Crossplane Core behavior or recommended practice without primary Crossplane corroboration. Exclude changes that only repair incorrect assertions, output, rendering, panics, or integration behavior.
+
+## Shared contract
+
+Before research, read and follow `.agents/skills/okf-updates/SKILL.md`, especially its stable identity rules, relevance exclusions, and researcher output contract.
+
+Use only the exact comparison range supplied by the parent agent. Return `candidates: []` when the stable update contains no qualifying feature. Do not include security fixes, small bugs, dependency churn, CI, refactors, or prerelease behavior to make the result look useful.
+
+Use immutable, commit-pinned source links with line ranges whenever practical. Release notes may identify a lead, but implementation, schemas, tests, or examples must support every reported capability.
+
+Do not edit files, source locks, catalog content, branches, commits, pull requests, issues, or other GitHub state. Do not start nested subagents.

--- a/.agents/skills/okf-updates/SKILL.md
+++ b/.agents/skills/okf-updates/SKILL.md
@@ -22,7 +22,9 @@ Check exactly these configured components unless the requester narrows the scope
 | Component ID | Repository | Current identity in `.okf/sources.lock.yaml` | Latest stable identity | Researcher |
 | --- | --- | --- | --- | --- |
 | `crossplane-core` | `crossplane/crossplane` | `sources.crossplane.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-crossplane-core-update-researcher` |
+| `crossplane-cli` | `crossplane/cli` | `sources.crossplane-cli.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-crossplane-cli-update-researcher` |
 | `crossplane-runtime` | `crossplane/crossplane-runtime` | `sources.crossplane-runtime.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-crossplane-runtime-update-researcher` |
+| `xprin` | `crossplane-contrib/xprin` | `sources.xprin.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-xprin-update-researcher` |
 | `function-sequencer` | `crossplane-contrib/function-sequencer` | `sources.function-sequencer.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-function-sequencer-update-researcher` |
 | `function-go-templating` | `crossplane-contrib/function-go-templating` | `sources.function-go-templating.tag` and `commit` | highest stable semantic-version tag and its full commit | `okf-function-go-templating-update-researcher` |
 | `crossplane-docs` | `crossplane/docs` | `sources.crossplane-docs.series` and `commit` | documentation series matching the latest stable Crossplane major.minor plus the newest commit touching `content/v<major>.<minor>/**` | `okf-crossplane-docs-update-researcher` |
@@ -87,7 +89,7 @@ Researchers must use only the assigned repository and comparison range, except w
 Report a candidate only when the stable comparison adds a user-facing capability that could improve this OKF bundle, such as:
 
 - a new public API, resource, field, command, interface, helper, template function, input option, or supported workflow
-- a new composition, reconciliation, readiness, dependency, rendering, provider-development, or documentation capability
+- a new composition, reconciliation, readiness, dependency, rendering, testing, assertion, provider-development, or documentation capability
 - a previously prerelease capability that becomes available in a stable release
 - a new official stable-series guide that explains a released capability not already represented in the catalog
 

--- a/.codex/agents/okf-crossplane-cli-update-researcher.toml
+++ b/.codex/agents/okf-crossplane-cli-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-crossplane-cli-update-researcher"
+description = "Read-only researcher for relevant new Crossplane CLI capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-crossplane-cli-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.codex/agents/okf-xprin-update-researcher.toml
+++ b/.codex/agents/okf-xprin-update-researcher.toml
@@ -1,0 +1,6 @@
+name = "okf-xprin-update-researcher"
+description = "Read-only researcher for relevant new xprin capabilities between two stable releases."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = "Before doing any work, read and follow `.agents/agents/okf-xprin-update-researcher/AGENT.md` as the canonical role instructions."

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .venv/
 .env
 compose.override.yaml
+.DS_Store

--- a/.okf/sources.lock.yaml
+++ b/.okf/sources.lock.yaml
@@ -22,9 +22,12 @@ sources:
     resolved_at: 2026-07-16
   crossplane:
     repository: crossplane/crossplane
-    tag: v2.3.3
-    commit: 09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d
-    resolved_at: 2026-07-14
+    tag: v2.4.0
+    commit: 61fa450c0c14a75bf5632872bd4a5b6945ec5a26
+    previous_tag: v2.3.3
+    previous_commit: 09ffaea39ccaea0f80817e35b5bbd3632b4e7e0d
+    selected_by: user-requested update-discovery checkpoint and provider-development orientation; no feature selected
+    resolved_at: 2026-09-05
   crossplane-v2.0.0:
     repository: crossplane/crossplane
     tag: v2.0.0
@@ -61,16 +64,10 @@ sources:
     resolved_at: 2026-07-14
   crossplane-docs:
     repository: crossplane/docs
-    series: v2.3
-    commit: f1315464e35d40d25a28e4c15b6725b0e21adf91
-    selected_by: crossplane/v2.3.3
-    resolved_at: 2026-07-14
-  crossplane-v2.4.0:
-    repository: crossplane/crossplane
-    tag: v2.4.0
-    commit: 61fa450c0c14a75bf5632872bd4a5b6945ec5a26
-    selected_by: current stable release for provider-development orientation
-    resolved_at: 2026-08-21
+    series: v2.4
+    commit: 1c17fdbf7fbadbb2399a40f86885deac0a35b867
+    selected_by: user-requested update-discovery checkpoint; no feature selected
+    resolved_at: 2026-09-05
   crossplane-docs-v2.4:
     repository: crossplane/docs
     series: v2.4
@@ -201,11 +198,12 @@ sources:
     resolved_at: 2026-08-21
   function-go-templating:
     repository: crossplane-contrib/function-go-templating
-    tag: v0.12.2
-    commit: 0a1e6d386f4363fae257ddbfb5b497416370e830
-    previous_tag: v0.12.1
-    previous_commit: 548ae34fd9c843f0747981894fb7fa0ff1ba47fa
-    resolved_at: 2026-07-14
+    tag: v0.12.4
+    commit: fe17e68927afd64046232f39a2376e87b45e2f58
+    previous_tag: v0.12.2
+    previous_commit: 0a1e6d386f4363fae257ddbfb5b497416370e830
+    selected_by: user-requested update-discovery checkpoint; no feature selected
+    resolved_at: 2026-09-05
   function-go-templating-pr-498:
     repository: crossplane-contrib/function-go-templating
     commit: fba11b570e75660b1ff52b05979ba805baae1a51

--- a/.pi/agents/okf-crossplane-cli-update-researcher.md
+++ b/.pi/agents/okf-crossplane-cli-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-crossplane-cli-update-researcher
+description: Read-only researcher for relevant new Crossplane CLI capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-crossplane-cli-update-researcher/AGENT.md` as the canonical role instructions.

--- a/.pi/agents/okf-xprin-update-researcher.md
+++ b/.pi/agents/okf-xprin-update-researcher.md
@@ -1,0 +1,14 @@
+---
+name: okf-xprin-update-researcher
+description: Read-only researcher for relevant new xprin capabilities between two stable releases.
+tools: read, grep, find, ls, bash
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+async: false
+turnBudget: {"maxTurns":14,"graceTurns":1}
+maxSubagentDepth: 0
+---
+
+Before doing any work, read and follow `.agents/agents/okf-xprin-update-researcher/AGENT.md` as the canonical role instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,12 +38,14 @@ This repository contains an Open Knowledge Format (OKF) knowledge bundle for the
 - Use `okf-crossplane-core-docs-researcher` for current stable Crossplane Core documentation.
 - Use `okf-crossplane-core-code-researcher` for current stable Crossplane Core CRDs under `cluster/crds`.
 - Use `okf-crossplane-core-design-researcher` only as a last-resort historical-context source for a specific Core feature already identified from current stable documentation or implementation evidence. Never use it for general feature discovery.
+- Use `okf-crossplane-cli-update-researcher` only for stable-release CLI update discovery, including new commands, flags, project workflows, rendering, packaging, and validation behavior.
+- Use `okf-xprin-update-researcher` only for stable-release xprin update discovery, including new assertion, suite, rendering, and test-runner capabilities.
 - Use `okf-function-go-templating-researcher` for user-facing `function-go-templating` installation, input schema, examples, and additional template functions.
 - Use `okf-function-go-templating-sprig-researcher` for the exact Sprig version exposed by the selected stable `function-go-templating` release.
 - Use `okf-function-go-templating-project-history-researcher` for human-authored issues and pull requests related to that function.
 - Use `okf-function-sdk-go-researcher` for developer-facing `crossplane/function-sdk-go` APIs, helpers, examples, and testing utilities.
 - Use `okf-function-tag-manager-researcher` for user-facing `crossplane-contrib/function-tag-manager` installation, input schema, tag-management behavior, supported-resource filters, and examples.
-- Use the matching `*-update-researcher` only from the explicit `$okf-updates` workflow and only after its component identity changes.
+- Use every matching `*-update-researcher` only from the explicit `$okf-updates` workflow and only after its component identity changes.
 - Every composition function must have its own canonical instruction files and matching Codex and Pi adapters before its OKF concepts are generated.
 - Use the generic `okf-crossplane-researcher` only for domains without a dedicated agent, such as CLI, runtime, tools, native providers, and testing tools.
 - The Crossplane CLI is a separate catalog domain and is not part of Crossplane Core.


### PR DESCRIPTION
## Summary

- checkpoint discovered stable identities for Crossplane Core, docs, and function-go-templating
- remove the duplicate Crossplane v2.4.0 lock identity
- include Crossplane CLI and xprin in OKF update discovery
- add dedicated read-only update researchers and Codex/Pi adapters for both components

## Validation

- `mise run lint`
- OKF validation: 0 errors, 0 warnings
- MCP unit tests: 31 passed

The unrelated local `.gitignore` modification is not included.