### PR TITLE
Clarify Control Plane Project lifecycle and agent choice

### DIFF
--- a/.okf/claim-ledger.md
+++ b/.okf/claim-ledger.md
@@ -15,7 +15,9 @@ advanced. The official CLI documentation is the authority for the documented
 workflow and explicit Beta state. CLI source is used only to establish the
 project metadata boundary. Claims, deprecated XRD v1, legacy v1 XR semantics,
 historical design, and project history were excluded. No source text or
-examples were copied or adapted.
+examples were copied or adapted. Revalidated 2026-09-05: the Beta state applies
+to the command workflow, while the separate `dev.crossplane.io/v1alpha1`
+Project metadata API is Alpha.
 
 | Concept | Exact claim | Class | Source role | Confidence | Feature state / evidence |
 |---|---|---|---|---|---|
@@ -25,7 +27,7 @@ examples were copied or adapted.
 | cli/control-plane-projects | In a project directory, local Composition rendering discovers and builds embedded Functions without the standalone Functions manifest argument. | documented-guidance | official-documentation | direct | Beta project workflow; [project-mode rendering](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L925-L1032) |
 | cli/control-plane-projects | `crossplane project run` creates a KIND development control plane and local registry, builds and pushes embedded Function and Configuration packages, installs the Configuration, and selects that cluster in kubectl. | documented-guidance | official-documentation | direct | Beta project workflow; [local project run](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1034-L1058) |
 | cli/control-plane-projects | Project build and push provide the documented route to package a project for an existing Crossplane cluster. | documented-guidance | official-documentation | direct | Beta project workflow; [build and push](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1105-L1128) |
-| cli/control-plane-projects | The Project metadata type is not a Kubernetes resource; it describes a buildable Configuration and its repository, dependencies, Functions, paths, architectures, and schema generation. | API | primary | direct | The containing project command workflow is explicitly Beta; [Project API](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120), [project paths](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L150-L171) |
+| cli/control-plane-projects | The Project metadata type is not a Kubernetes resource; it describes a buildable Configuration and its repository, dependencies, Functions, paths, architectures, and schema generation. | API | primary | direct | Alpha for the Project metadata API because the project file uses `dev.crossplane.io/v1alpha1`; [Project API](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120), [project paths](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L150-L171), [documented API version](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L127-L141) |
 
 The instruction to ask before wrapping a new Composition is a user-requested
 catalog authoring policy. It is intentionally labelled as such and is not

--- a/catalog/cli/control-plane-projects.md
+++ b/catalog/cli/control-plane-projects.md
@@ -4,7 +4,7 @@ title: Opt in to a Crossplane control plane project
 description: Choose the Beta CLI project wrapper explicitly before scaffolding, locally running, and packaging a new Composition-backed API.
 resource: https://docs.crossplane.io/cli/latest/get-started/get-started-with-control-plane-projects/
 tags: [crossplane, cli, composition, project, authoring, packaging]
-generated: { by: "process:crossplane-okf-generation", at: "2026-08-20T23:35:21Z" }
+generated: { by: "process:crossplane-okf-generation", at: "2026-09-05T14:34:46Z" }
 sources:
   - id: project-command-beta-state
     resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/command-reference.md#L1095-L1103
@@ -36,6 +36,9 @@ sources:
   - id: project-api-boundary
     resource: https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120
     title: Project metadata API boundary
+  - id: project-metadata-api-version
+    resource: https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L127-L141
+    title: Project metadata API version
 documentation_series: cli-v2.4
 source_repository: crossplane/docs
 source_commit: f51137d2f8e92a167bb580be528c78b879ed406d
@@ -48,7 +51,9 @@ supporting_sources:
     paths:
       - apis/dev/v1alpha1/project_types.go
 feature_state: Beta
-feature_state_basis: The locked CLI v2.4 command reference explicitly labels the crossplane project command group Beta and warns that Beta features may change.
+feature_state_basis: The locked CLI v2.4 command reference explicitly labels the crossplane project command workflow Beta and warns that Beta features may change.
+project_metadata_api_feature_state: Alpha
+project_metadata_api_feature_state_basis: The project file uses dev.crossplane.io/v1alpha1; this state applies only to the Project metadata API.
 ---
 
 # Agent opt-in gate
@@ -111,8 +116,10 @@ authoring lifecycle:
 
 - Project commands are Beta; do not hide that lifecycle state when offering
   the option.[^project-command-beta-state]
-- `crossplane-project.yaml` uses the CLI's Project metadata type. It describes
-  a buildable Configuration and its dependencies, Functions, paths,
+- `crossplane-project.yaml` uses the CLI's `dev.crossplane.io/v1alpha1`
+  Project metadata API, so that API is **Alpha** even though the surrounding
+  command workflow is Beta.[^project-metadata-api-version] The metadata
+  describes a buildable Configuration and its dependencies, Functions, paths,
   architectures, and schema generation; it is not a Kubernetes resource and
   has no status.[^project-api-boundary]
 - Local project execution requires a Docker-compatible runtime because the
@@ -136,3 +143,4 @@ authoring lifecycle:
 [^project-build-and-push-workflow]: [Project build and push workflow](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L1105-L1128)
 [^xrd-generation-boundary]: [Example-XR XRD generation boundary](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L235-L238)
 [^project-api-boundary]: [Project metadata API boundary](https://github.com/crossplane/cli/blob/ef9b974770a45e085aacee3b2cdda6284ab6cf51/apis/dev/v1alpha1/project_types.go#L69-L120)
+[^project-metadata-api-version]: [Project metadata API version](https://github.com/crossplane/docs/blob/f51137d2f8e92a167bb580be528c78b879ed406d/content/cli/v2.4/get-started/get-started-with-control-plane-projects.md#L127-L141)

--- a/catalog/log.md
+++ b/catalog/log.md
@@ -1,5 +1,8 @@
 # Catalog Update Log
 
+## 2026-09-05
+* **Correction**: Distinguished the Beta `crossplane project` command workflow from the Alpha `dev.crossplane.io/v1alpha1` Project metadata API, and made the project-versus-standalone question explicit in the agent-facing Crossplane skill.
+
 ## 2026-08-21
 * **Creation**: Added an explicit opt-in decision for wrapping new Compositions as Beta Crossplane control plane projects, while preserving and clarifying the standalone manifest route.
 * **Creation**: Added a provider-development SDK route from an immutable provider-template snapshot through modern managed-resource APIs, ProviderConfig and credentials, typed reconciliation, generation, testing, and xpkg packaging.

--- a/skills/crossplane-v2-okf/SKILL.md
+++ b/skills/crossplane-v2-okf/SKILL.md
@@ -14,6 +14,17 @@ For every Crossplane v2 ecosystem question, use the OKF MCP tools before answeri
 3. For building, authoring, designing, or substantially reviewing a Crossplane v2 Composition, retrieve **Develop a Crossplane v2 Composition** (`composition-developer-starter`) as the primary routing guide. Follow its links to required API, provider, function, security, readiness, identity, testing, and packaging concepts.
 4. Use `okf_search` and `okf_get_concept` for exact concepts or API details; use `okf_related` or `okf_impact` only when relationships matter.
 
+Before creating files for a new Composition or Composition-backed API, ask the
+requester this question unless they already selected a structure:
+
+> Would you like this wrapped as a Crossplane control plane project (CLI Beta),
+> or should I create standalone Composition manifests?
+
+Treat the project wrapper as an explicit opt-in. Do not initialize a project,
+add `crossplane-project.yaml`, or reorganize existing manifests unless the
+requester chooses project mode. This is an agent authoring policy, not a
+Crossplane requirement.
+
 The Composition developer starter is a navigation route, not provider-specific evidence. Use the provider workflow below for concrete managed-resource schemas, examples, and upstream Terraform documentation.
 
 ## Provider-family packages


### PR DESCRIPTION
## Summary
- distinguish the Beta crossplane project command workflow from the Alpha dev.crossplane.io/v1alpha1 Project metadata API
- record the corrected lifecycle boundary in the claim ledger and catalog log
- require agents to ask project-versus-standalone before creating a new Composition unless the requester already chose a structure

## Validation
- mise run validate
- env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false mise run lint (31 tests passed)
- okf-reviewer: APPROVED